### PR TITLE
Suggestions to improve README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,4 @@
 
 ### Features
 
-* **initial-release:** adds flag for generating CHANGELOG.md on the first release. ([b812b44](https://github.com/bcoe/conventional-recommended-workflow/commit/b812b44))
-
-
-
+* **initial-release:** adds flag for generating CHANGELOG.md on the first release. ([b812b44](https://github.com/conventional-changelog/standard-version/commit/b812b44))

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the workflow outlined in [conventional-changelog-cli](https://github.com/stevema
 **how it works:**
 
 1. when you land commits on your `master` branch, select the _Squash and Merge_ option.
-2. add a title and body that follows the [conventional-changelog conventions](https://github.com/stevemao/conventional-changelog-angular/blob/master/convention.md).
+2. add a title and body that follows the [conventional-changelog conventions](https://github.com/conventional-changelog/conventional-changelog-angular/blob/master/convention.md).
 3. when you're ready to release to npm:
   1. checkout `master`.
   2. run `standard-version`.

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 
 > stop using `npm version`, use `standard-version` it does so much more:
 
-Automatic release and CHANGELOG management, using GitHub's new squash button and
-the workflow outlined in [conventional-changelog-cli](https://github.com/stevemao/conventional-changelog-cli).
+Automatic versioning and CHANGELOG management, using GitHub's new squash button and
+the [recommended workflow](https://github.com/conventional-changelog/conventional-changelog-cli#recommended-workflow) for `conventional-changelog`.
 
 **how it works:**
 
 1. when you land commits on your `master` branch, select the _Squash and Merge_ option.
-2. add a title and body that follows the [conventional-changelog conventions](https://github.com/conventional-changelog/conventional-changelog-angular/blob/master/convention.md).
+2. add a title and body that follows the [standard-changelog conventions](https://github.com/conventional-changelog/conventional-changelog-angular/blob/master/convention.md).
 3. when you're ready to release to npm:
   1. `git checkout master; git pull origin master`.
   2. run `standard-version`.
@@ -65,7 +65,7 @@ To generate your changelog for the first time, simply do:
 ```sh
 # npm run script
 npm run release -- --first-release
-# global bin
+# or global bin
 standard-version --first-release
 ```
 
@@ -76,7 +76,7 @@ If you typically use `npm version` as a manual pre-publish step, do this instead
 ```sh
 # npm run script
 npm run release
-# global bin
+# or global bin
 standard-version
 ```
 
@@ -87,7 +87,7 @@ As long as your git commit messages are conventional and accurate, you no longer
 ```sh
 # npm run script
 npm run release -- --help
-# global bin
+# or global bin
 standard-version --help
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,18 +82,6 @@ standard-version
 
 As long as your git commit messages are conventional and accurate, you no longer need to specify the semver type.
 
-### Automating
-
-You can even run `standard-version` automatically on `npm publish`. Just add the following to _package.json_:
-
-```json
-{
-  "scripts": {
-    "prepublish": "standard-version && git push --follow-tags origin master"
-  }
-}
-```
-
 ### CLI Help
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ the workflow outlined in [conventional-changelog-cli](https://github.com/stevema
 1. when you land commits on your `master` branch, select the _Squash and Merge_ option.
 2. add a title and body that follows the [conventional-changelog conventions](https://github.com/conventional-changelog/conventional-changelog-angular/blob/master/convention.md).
 3. when you're ready to release to npm:
-  1. checkout `master`.
+  1. `git checkout master; git pull origin master`.
   2. run `standard-version`.
-  3. `git push --tags; git push origin master; npm publish`.
+  3. `git push --follow-tags origin master; npm publish`.
 
 `standard-version` does the following:
 

--- a/README.md
+++ b/README.md
@@ -24,19 +24,17 @@ the workflow outlined in [conventional-changelog-cli](https://github.com/stevema
 3. commits _package.json_ and _CHANGELOG.md_.
 4. tags a new release.
 
-## Initial CHANGELOG.md Generation
-
-When you're generating your changelog for the first time, simply do:
-
-`standard-version --first-release`
-
 ## Installation
 
-`npm i standard-version`
+### As `npm run` script
 
-## Automating
+Install and add to `devDependencies`:
 
-Add this to your _package.json_
+```
+npm i --save-dev standard-version
+```
+
+Add an [`npm run` script](https://docs.npmjs.com/cli/run-script) to your _package.json_:
 
 ```json
 {
@@ -44,6 +42,65 @@ Add this to your _package.json_
     "release": "standard-version"
   }
 }
+```
+
+Now you can use `npm run release` in place of `npm version`.
+
+### As global bin
+
+Install globally (add to your `PATH`):
+
+```
+npm i -g standard-version
+```
+
+Now you can use `standard-version` in place of `npm version`.
+
+## Usage
+
+### Initial CHANGELOG.md Generation
+
+To generate your changelog for the first time, simply do:
+
+```sh
+# npm run script
+npm run release -- --first-release
+# global bin
+standard-version --first-release
+```
+
+### Manual Pre-Publish
+
+If you typically use `npm version` as a manual pre-publish step, do this instead:
+
+```sh
+# npm run script
+npm run release
+# global bin
+standard-version
+```
+
+As long as your git commit messages are conventional and accurate, you no longer need to specify the semver type.
+
+### Automating
+
+You can even run `standard-version` automatically on `npm publish`. Just add the following to _package.json_:
+
+```json
+{
+  "scripts": {
+    "prepublish": "standard-version && git push --follow-tags origin master"
+  }
+}
+```
+
+### CLI Help
+
+```sh
+# npm run script
+npm run release -- --help
+# global bin
+standard-version --help
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "automatic",
     "workflow",
     "version",
-    "angular"
+    "angular",
+    "standard"
   ],
   "author": "Ben Coe <ben@npmjs.com>",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/conventional-changelog/standard-verison.git"
+    "url": "git+https://github.com/conventional-changelog/standard-version.git"
   },
   "keywords": [
     "conventional-changelog",


### PR DESCRIPTION
Highlights:

1. Update links to account for new GitHub org
2. Attempt to clarify commands and steps in **how it works:**
3. Expand **Installation** section to show options for npm run script and global bin
4. Add **Usage** section (and move **Initial CHANGELOG.md Generation** under it)
5. ~~Explain how to use a _prepublish_ lifecycle script in the **Automating** section~~ Remove **Automating** section

Note that this **does not** attempt to address concerns in #3.

Let me know what you think.