### PR TITLE
add blurb about semantic-release vs. conventional changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ Add this to your _package.json_
 }
 ```
 
+## What Is Conventional Changelog
+
+Conventional Changelog is a tool for generating slick looking CHANGELOG.md files
+from your project's git history. There are various standards for how you
+annotate your commits; `conventional-recommended-workflow` defaults to `angular`'s
+commit standard.
+
+**Relationship with Semantic Release:**
+
+[semantic-release](https://github.com/semantic-release/semantic-release) is a tool
+for fully automating the package publication process. `semantic-release` is also
+based around the `angular` commit format, and relies on some libraries in the
+`conventional-changelog` ecosystem.
+
 ## License
 
 ISC


### PR DESCRIPTION
Added blurb about the relationship between semantic-release and conventional-changelog. see #3 

CC: @stevemao, @boennemann