### PR TITLE
slight changes to conventions, to help get more buy-in from npm peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Coverage Status](https://coveralls.io/repos/conventional-changelog/standard-version/badge.svg?branch=)](https://coveralls.io/r/conventional-changelog/standard-version?branch=master)
 [![Standard Version](https://img.shields.io/badge/standard-version-brightgreen.svg)](https://github.com/conventional-changelog/standard-version)
 
-> stop using `npm version`, use `standard-version` it makes your life way easier:
+> stop using `npm version`, use `standard-version` it makes your life way easier.
 
 Automatic release and CHANGELOG management, using GitHub's new squash button and
 the workflow outlined in [conventional-changelog-standard](https://github.com/bcoe/conventional-changelog-standard/blob/master/convention.md).
@@ -22,7 +22,7 @@ _how it works:_
 `standard-version` does the following:
 
 1. bumps the version in package.json (based on your commit history).
-2. runs `conventional-changelog` and updates CHANGELOG.md.
+2. runs `conventional-changelog` and updates _CHANGELOG.md._
 3. commits _package.json_ and _CHANGELOG.md_.
 4. tags a new release.
 

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 [![Coverage Status](https://coveralls.io/repos/conventional-changelog/standard-version/badge.svg?branch=)](https://coveralls.io/r/conventional-changelog/standard-version?branch=master)
 [![Standard Version](https://img.shields.io/badge/standard-version-brightgreen.svg)](https://github.com/conventional-changelog/standard-version)
 
-> stop using `npm version`, use `standard-version` it does so much more:
+> stop using `npm version`, use `standard-version` it makes your life way easier:
 
 Automatic release and CHANGELOG management, using GitHub's new squash button and
-the workflow outlined in [conventional-changelog-cli](https://github.com/stevemao/conventional-changelog-cli).
+the workflow outlined in [conventional-changelog-standard](https://github.com/bcoe/conventional-changelog-standard/blob/master/convention.md).
 
-**how it works:**
+_how it works:_
 
 1. when you land commits on your `master` branch, select the _Squash and Merge_ option.
-2. add a title and body that follows the [conventional-changelog conventions](https://github.com/stevemao/conventional-changelog-angular/blob/master/convention.md).
+2. add a title and body that follows the [conventional-changelog-standard conventions](https://github.com/bcoe/conventional-changelog-standard/blob/master/convention.md).
 3. when you're ready to release to npm:
   1. checkout `master`.
   2. run `standard-version`.
@@ -34,7 +34,7 @@ When you're generating your changelog for the first time, simply do:
 
 ## Installation
 
-`npm i standard-version`
+`npm i standard-version -g`
 
 ## Automating
 
@@ -50,6 +50,35 @@ Add this to your _package.json_
     "release": "standard-version"
   }
 }
+```
+
+## Commit Message Convention, at a Glance
+
+_patches:_
+
+```sh
+-m "fix(parsing): fixed a bug in our parser"
+```
+
+_features:_
+
+```sh
+git commit -a -m "feat(parser): we now have a parser \o/"
+```
+
+_breaking changes:_
+
+```sh
+git commit -a -m "feat(new-parser):
+BREAKING CHANGE: swapping out our old parser for a new one"
+```
+
+_other changes:_
+
+You decide, e.g., docs, chore, etc.
+
+```sh
+git commit -a -m "docs: fixed up the docs a bit"
 ```
 
 ## Badges!

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-var conventionalChangelog = require('conventional-changelog')
 var conventionalRecommendedBump = require('conventional-recommended-bump')
+var conventionalChangelog = require('conventional-changelog')
 var path = require('path')
 var argv = require('yargs')
   .usage('Usage: $0 [options]')
@@ -8,12 +8,6 @@ var argv = require('yargs')
     alias: 'i',
     describe: 'Read the CHANGELOG from this file',
     default: 'CHANGELOG.md',
-    global: true
-  })
-  .option('preset', {
-    alias: 'p',
-    describe: 'Name of the preset you want to use. Must be one of the following:\nangular, atom, codemirror, ember, eslint, express, jquery, jscs, or jshint',
-    default: 'angular',
     global: true
   })
   .option('message', {
@@ -48,7 +42,7 @@ var semver = require('semver')
 var util = require('util')
 
 conventionalRecommendedBump({
-  preset: argv.preset
+  preset: 'angular'
 }, function (err, release) {
   if (err) {
     console.error(chalk.red(err.message))
@@ -82,7 +76,7 @@ function outputChangelog (argv, cb) {
   }
   var content = ''
   var changelogStream = conventionalChangelog({
-    preset: argv.preset,
+    preset: 'standard',
     outputUnreleased: true,
     pkg: {
       path: path.resolve(process.cwd(), './package.json')

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "conventional-changelog": "^1.1.0",
+    "conventional-changelog-standard": "^1.1.0",
     "conventional-recommended-bump": "^0.2.0",
     "figures": "^1.5.0",
     "fs-access": "^1.0.0",

--- a/test.js
+++ b/test.js
@@ -78,4 +78,19 @@ describe('cli', function () {
       content.should.not.match(/legacy header format/)
     })
   })
+
+  it('handles commit messages longer than 80 characters', function () {
+    fs.writeFileSync('package.json', JSON.stringify({
+      version: '1.0.0'
+    }), 'utf-8')
+
+    commit('feat: first commit')
+    shell.exec('git tag -a v1.0.0 -m "my awesome first release"')
+    commit('fix: this is my fairly long commit message which is testing whether or not we allow for long commit messages')
+
+    shell.exec(cliPath).code.should.equal(0)
+
+    var content = fs.readFileSync('CHANGELOG.md', 'utf-8')
+    content.should.match(/this is my fairly long commit message which is testing whether or not we allow for long commit messages/)
+  })
 })


### PR DESCRIPTION
* based on a conversation with @ceejbot, I've forked the `angular` commit standards and lifted the character-length restrictions. This might be a bit controversial, but this helps me get more buy-in from other folks at npm, Inc.
* I've introduced a style guide specifically for `standard-version`, since we might have more opinionated changes in the future.