### PR TITLE
fix: we had too many \n characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ function outputChangelog (argv, cb) {
 
   changelogStream.on('end', function () {
     checkpoint('outputting changes to %s', [argv.infile])
-    fs.writeFileSync(argv.infile, header + '\n' + content + oldContent, 'utf-8')
+    fs.writeFileSync(argv.infile, header + '\n' + (content + oldContent).replace(/\n+$/, '\n'), 'utf-8')
     return cb()
   })
 }


### PR DESCRIPTION
we were appending too many `\n` characters, which causes some text editors to truncate content when they first open the CHANGELOG.