### PR TITLE
Tag signing

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,13 @@ var argv = require('yargs')
     default: false,
     global: true
   })
+  .option('sign-tag', {
+    alias: 's',
+    describe: 'Should the git tag be signed?',
+    type: 'boolean',
+    default: false,
+    global: true
+  })
   .help()
   .alias('help', 'h')
   .example('$0', 'Update changelog and tag release')
@@ -123,8 +130,14 @@ function formatCommitMessage (msg, newVersion) {
 }
 
 function tag (newVersion, argv) {
+  var tagOption
+  if (argv.signTag) {
+    tagOption = '-s '
+  } else {
+    tagOption = '-a '
+  }
   checkpoint('tagging release %s', [newVersion])
-  exec('git tag -a v' + newVersion + ' -m "' + argv.message + '"', function (err, stdout, stderr) {
+  exec('git tag ' + tagOption + 'v' + newVersion + ' -m "' + argv.message + '"', function (err, stdout, stderr) {
     var errMessage = null
     if (err) errMessage = err.message
     if (stderr) errMessage = stderr


### PR DESCRIPTION
Hi!

This PR is related to #15

`git tag -m` already creates an annotated tags, without explicitly given an
`-a` (unsigned tag) or `-s` (signed tag) option (See [git-tag man page][git-tag-man]).

From [Git 2.9][git2-9] the configuration variable `tag.forceSignAnnotated` enables to turn on
tag signing by default, in the case where `-a` is omitted.

Note: Git 2.9 is a coming release.

[git-tag-man]: https://www.kernel.org/pub/software/scm/git/docs/git-tag.html
[git2-9]: https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/2.9.0.txt