### PR TITLE
fix: format the annotated tag message

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ function formatCommitMessage (msg, newVersion) {
 
 function tag (newVersion, argv) {
   checkpoint('tagging release %s', [newVersion])
-  exec('git tag -a v' + newVersion + ' -m "' + argv.message + '"', function (err, stdout, stderr) {
+  exec('git tag -a v' + newVersion + ' -m "' + formatCommitMessage(argv.message, newVersion) + '"', function (err, stdout, stderr) {
     var errMessage = null
     if (err) errMessage = err.message
     if (stderr) errMessage = stderr

--- a/test.js
+++ b/test.js
@@ -93,4 +93,21 @@ describe('cli', function () {
     var content = fs.readFileSync('CHANGELOG.md', 'utf-8')
     content.should.match(/this is my fairly long commit message which is testing whether or not we allow for long commit messages/)
   })
+
+  it('formats the commit and tag messages appropriately', function () {
+    fs.writeFileSync('package.json', JSON.stringify({
+      version: '1.0.0'
+    }), 'utf-8')
+
+    commit('feat: first commit')
+    shell.exec('git tag -a v1.0.0 -m "my awesome first release"')
+    commit('feat: new feature!')
+
+    shell.exec(cliPath).code.should.equal(0)
+
+    // check last commit message
+    shell.exec('git log --oneline -n1').stdout.should.match(/chore\(release\)\: 1\.1\.0/)
+    // check annotated tag message
+    shell.exec('git tag -l -n1 v1.1.0').stdout.should.match(/chore\(release\)\: 1\.1\.0/)
+  })
 })


### PR DESCRIPTION
Fixes #19. (Sorry @Conaclos I didn't realize the problem until today.)

We are formatting the commit message such that e.g.
`chore(release): %s` → `chore(release): 1.0.0`.

But I failed to notice we were **not** formatting the message for the annotated tag, so [as you can see](https://github.com/conventional-changelog/standard-version/releases/tag/v2.1.2) it stays as `chore(release): %s`.

<img width="572" alt="screen shot 2016-04-29 at 4 04 48 pm" src="https://cloud.githubusercontent.com/assets/1929625/14928196/61bd29de-0e24-11e6-97a2-5839dbbaffe4.png">

Whoops!

This adds a test to verify the messages for the commit and for the tag, and fixes the issue.