### PR TITLE
feat: add --sign flag to sign git commit and tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,13 @@ var argv = require('yargs')
     default: false,
     global: true
   })
+  .option('sign-tag', {
+    alias: 's',
+    describe: 'Should the git tag be signed?',
+    type: 'boolean',
+    default: false,
+    global: true
+  })
   .help()
   .alias('help', 'h')
   .example('$0', 'Update changelog and tag release')
@@ -123,8 +130,14 @@ function formatCommitMessage (msg, newVersion) {
 }
 
 function tag (newVersion, argv) {
+  var tagOption
+  if (argv.signTag) {
+    tagOption = '-s '
+  } else {
+    tagOption = '-a '
+  }
   checkpoint('tagging release %s', [newVersion])
-  exec('git tag -a v' + newVersion + ' -m "' + formatCommitMessage(argv.message, newVersion) + '"', function (err, stdout, stderr) {
+  exec('git tag ' + tagOption + 'v' + newVersion + ' -m "' + formatCommitMessage(argv.message, newVersion) + '"', function (err, stdout, stderr) {
     var errMessage = null
     if (err) errMessage = err.message
     if (stderr) errMessage = stderr

--- a/index.js
+++ b/index.js
@@ -24,9 +24,9 @@ var argv = require('yargs')
     default: false,
     global: true
   })
-  .option('sign-tag', {
+  .option('sign', {
     alias: 's',
-    describe: 'Should the git tag be signed?',
+    describe: 'Should the git commit and tag be signed?',
     type: 'boolean',
     default: false,
     global: true
@@ -113,7 +113,7 @@ function commit (argv, newVersion, cb) {
     args.unshift('package.json')
   }
   checkpoint(msg, args)
-  exec('git add package.json ' + argv.infile + ';git commit package.json ' + argv.infile + ' -m "' + formatCommitMessage(argv.message, newVersion) + '"', function (err, stdout, stderr) {
+  exec('git add package.json ' + argv.infile + ';git commit ' + (argv.sign ? '-S ' : '') + 'package.json ' + argv.infile + ' -m "' + formatCommitMessage(argv.message, newVersion) + '"', function (err, stdout, stderr) {
     var errMessage = null
     if (err) errMessage = err.message
     if (stderr) errMessage = stderr
@@ -131,7 +131,7 @@ function formatCommitMessage (msg, newVersion) {
 
 function tag (newVersion, argv) {
   var tagOption
-  if (argv.signTag) {
+  if (argv.sign) {
     tagOption = '-s '
   } else {
     tagOption = '-a '

--- a/test.js
+++ b/test.js
@@ -79,6 +79,20 @@ describe('cli', function () {
     })
   })
 
+  it('respects the --sign option', function () {
+    fs.writeFileSync('package.json', JSON.stringify({
+      version: '1.0.0'
+    }), 'utf-8')
+
+    commit('feat: first commit')
+
+    // this should fail without a GPG key
+    var result = shell.exec(cliPath + ' --sign')
+    result.code.should.equal(1)
+    result.stdout.should.match(/gpg\: signing failed\: secret key not available/)
+    result.stdout.should.match(/error\: gpg failed to sign the data/)
+  })
+
   it('handles commit messages longer than 80 characters', function () {
     fs.writeFileSync('package.json', JSON.stringify({
       version: '1.0.0'


### PR DESCRIPTION
Builds on top of (and replaces) #18, with the following additions:

- Sign the commit as well as the tag
- Change the CLI option to `--sign` (instead of `--sign-tag`) and update the description
- Add a test that verifies GPG signing was attempted by git (and failed from lack of key)