### PR TITLE
fix: upgrade, switch, pin dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ function outputChangelog (argv, cb) {
   }
   var content = ''
   var changelogStream = conventionalChangelog({
-    preset: 'standard',
+    preset: 'angular',
     outputUnreleased: true,
     pkg: {
       path: path.resolve(process.cwd(), './package.json')

--- a/package.json
+++ b/package.json
@@ -31,19 +31,19 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "conventional-changelog": "^1.1.0",
-    "conventional-changelog-standard": "^1.2.1",
-    "conventional-recommended-bump": "^0.2.0",
+    "conventional-changelog-angular": "^1.1.0",
+    "conventional-recommended-bump": "^0.2.1",
     "figures": "^1.5.0",
     "fs-access": "^1.0.0",
     "semver": "^5.1.0",
-    "yargs": "^4.3.2"
+    "yargs": "^4.6.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "coveralls": "^2.11.9",
     "mocha": "^2.4.5",
-    "nyc": "^6.2.1",
-    "shelljs": "^0.7.0",
+    "nyc": "^6.4.1",
+    "shelljs": "0.6.0",
     "standard": "^6.0.8"
   }
 }


### PR DESCRIPTION
* pinned shelljs to a version that works with nyc, [filed a bug](https://github.com/shelljs/shelljs/issues/438) regarding this.
* upgraded other dependencies.
* switched us back to angular changelog (fixes #27).