### PR TITLE
refactor(mockGit): modulization

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "chai": "^3.5.0",
     "coveralls": "^2.11.9",
     "mocha": "^2.4.5",
+    "mock-git": "1.0.0",
     "nyc": "^6.4.2",
     "shelljs": "^0.7.0",
     "standard": "^6.0.8"


### PR DESCRIPTION
https://github.com/stevemao/mock-git

The standalone module has a few improvements:
1. It is async
2. It uses temp folder for path which is better than `cwd`
3. It also handles some potential edge cases