### PR TITLE
feat: append eol to package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ conventionalRecommendedBump({
     newVersion = semver.inc(pkg.version, release.releaseAs)
     checkpoint('bumping version in package.json from %s to %s', [pkg.version, newVersion])
     pkg.version = newVersion
-    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + eol, 'utf-8')
+    fs.writeFileSync(pkgPath, (JSON.stringify(pkg, null, 2) + '\n').replace(/\n/, eol), 'utf-8')
   } else {
     console.log(chalk.red(figures.cross) + ' skip version bump on first release')
   }
@@ -76,7 +76,7 @@ conventionalRecommendedBump({
 
 function outputChangelog (argv, cb) {
   createIfMissing(argv)
-  var header = '# Change Log\n\nAll notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.\n'
+  var header = ['# Change Log', '', 'All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.', ''].join(eol)
   var oldContent = fs.readFileSync(argv.infile, 'utf-8')
   // find the position of the last release and remove header:
   if (oldContent.indexOf('<a name=') !== -1) {
@@ -101,7 +101,7 @@ function outputChangelog (argv, cb) {
 
   changelogStream.on('end', function () {
     checkpoint('outputting changes to %s', [argv.infile])
-    fs.writeFileSync(argv.infile, header + '\n' + (content + oldContent).replace(/\n+$/, '\n'), 'utf-8')
+    fs.writeFileSync(argv.infile, header + eol + (content + oldContent).replace(/\n+$/, eol), 'utf-8')
     return cb()
   })
 }
@@ -156,7 +156,7 @@ function createIfMissing (argv) {
     if (err.code === 'ENOENT') {
       checkpoint('created %s', [argv.infile])
       argv.outputUnreleased = true
-      fs.writeFileSync(argv.infile, '\n', 'utf-8')
+      fs.writeFileSync(argv.infile, eol, 'utf-8')
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ var pkgPath = path.resolve(process.cwd(), './package.json')
 var pkg = require(pkgPath)
 var semver = require('semver')
 var util = require('util')
+var eol = require('os').EOL
 
 conventionalRecommendedBump({
   preset: 'angular'
@@ -61,7 +62,7 @@ conventionalRecommendedBump({
     newVersion = semver.inc(pkg.version, release.releaseAs)
     checkpoint('bumping version in package.json from %s to %s', [pkg.version, newVersion])
     pkg.version = newVersion
-    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2), 'utf-8')
+    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + eol, 'utf-8')
   } else {
     console.log(chalk.red(figures.cross) + ' skip version bump on first release')
   }

--- a/index.js
+++ b/index.js
@@ -44,10 +44,9 @@ var exec = require('child_process').exec
 var fs = require('fs')
 var accessSync = require('fs-access').sync
 var pkgPath = path.resolve(process.cwd(), './package.json')
-var pkg = require(pkgPath)
 var semver = require('semver')
 var util = require('util')
-var eol = require('os').EOL
+var detectNewline = require('detect-newline').graceful
 
 conventionalRecommendedBump({
   preset: 'angular'
@@ -57,12 +56,17 @@ conventionalRecommendedBump({
     return
   }
 
+  var pkgContent = fs.readFileSync(pkgPath, 'utf-8')
+  var pkg = JSON.parse(pkgContent)
   var newVersion = pkg.version
   if (!argv.firstRelease) {
+    var oldEol = detectNewline(pkgContent)
     newVersion = semver.inc(pkg.version, release.releaseAs)
     checkpoint('bumping version in package.json from %s to %s', [pkg.version, newVersion])
     pkg.version = newVersion
-    fs.writeFileSync(pkgPath, (JSON.stringify(pkg, null, 2) + '\n').replace(/\n/, eol), 'utf-8')
+    pkgContent = JSON.stringify(pkg, null, 2)
+    var newEol = detectNewline(pkgContent)
+    fs.writeFileSync(pkgPath, (newEol !== oldEol ? pkgContent.replace(new RegExp(newEol, 'g'), oldEol) : pkgContent) + oldEol, 'utf-8')
   } else {
     console.log(chalk.red(figures.cross) + ' skip version bump on first release')
   }
@@ -76,8 +80,9 @@ conventionalRecommendedBump({
 
 function outputChangelog (argv, cb) {
   createIfMissing(argv)
-  var header = ['# Change Log', '', 'All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.', ''].join(eol)
   var oldContent = fs.readFileSync(argv.infile, 'utf-8')
+  var eol = detectNewline(oldContent)
+  var header = ['# Change Log', '', 'All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.', ''].join(eol)
   // find the position of the last release and remove header:
   if (oldContent.indexOf('<a name=') !== -1) {
     oldContent = oldContent.substring(oldContent.indexOf('<a name='))
@@ -101,7 +106,7 @@ function outputChangelog (argv, cb) {
 
   changelogStream.on('end', function () {
     checkpoint('outputting changes to %s', [argv.infile])
-    fs.writeFileSync(argv.infile, header + eol + (content + oldContent).replace(/\n+$/, eol), 'utf-8')
+    fs.writeFileSync(argv.infile, header + eol + (content + oldContent).replace(new RegExp(eol + '+$'), eol), 'utf-8')
     return cb()
   })
 }
@@ -156,7 +161,7 @@ function createIfMissing (argv) {
     if (err.code === 'ENOENT') {
       checkpoint('created %s', [argv.infile])
       argv.outputUnreleased = true
-      fs.writeFileSync(argv.infile, eol, 'utf-8')
+      fs.writeFileSync(argv.infile, require('os').EOL, 'utf-8')
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "conventional-changelog": "^1.1.0",
     "conventional-changelog-angular": "^1.1.0",
     "conventional-recommended-bump": "^0.2.1",
+    "detect-newline": "^2.1.0",
     "figures": "^1.5.0",
     "fs-access": "^1.0.0",
     "semver": "^5.1.0",

--- a/test.js
+++ b/test.js
@@ -4,7 +4,6 @@
 
 var shell = require('shelljs')
 var fs = require('fs')
-var eol = require('os').EOL
 var path = require('path')
 var mockGit = require('mock-git')
 var cliPath = path.resolve(__dirname, './index.js')
@@ -163,6 +162,15 @@ describe('cli', function () {
     shell.exec(cliPath).code.should.equal(0)
 
     var pkgJson = fs.readFileSync('package.json', 'utf-8')
-    pkgJson.should.equal(['{', '  "version": "1.0.1"', '}', ''].join(eol))
+    pkgJson.should.equal(['{', '  "version": "1.0.1"', '}', ''].join('\n'))
+  })
+
+  it('preserves existing newline chars in package.json', function () {
+    fs.writeFileSync('package.json', ['{', '  "version": "1.0.0"', '}', ''].join('\r\n'), 'utf-8')
+
+    shell.exec(cliPath).code.should.equal(0)
+
+    var pkgJson = fs.readFileSync('package.json', 'utf-8')
+    pkgJson.should.equal(['{', '  "version": "1.0.1"', '}', ''].join('\r\n'))
   })
 })

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@
 
 var shell = require('shelljs')
 var fs = require('fs')
+var eol = require('os').EOL
 var path = require('path')
 var mockGit = require('mock-git')
 var cliPath = path.resolve(__dirname, './index.js')
@@ -154,5 +155,14 @@ describe('cli', function () {
     shell.exec('git log --oneline -n1').stdout.should.match(/chore\(release\): 1\.1\.0/)
     // check annotated tag message
     shell.exec('git tag -l -n1 v1.1.0').stdout.should.match(/chore\(release\): 1\.1\.0/)
+  })
+
+  it('appends EOL at end of package.json', function () {
+    writePackageJson('1.0.0')
+
+    shell.exec(cliPath).code.should.equal(0)
+
+    var pkgJson = fs.readFileSync('package.json', 'utf-8')
+    pkgJson.should.equal(['{', '  "version": "1.0.1"', '}', ''].join(eol))
   })
 })


### PR DESCRIPTION
Fixes #37.

I'm thinking we should probably replace all `\n` characters with `os.EOL` to be more Windows friendly. I separated the commits so I can easily revert the 2nd one if you disagree.