### PR TITLE
Add a --no-verify option to prevent git hooks from being verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ As long as your git commit messages are conventional and accurate, you no longer
 
 After you cut a release, you can push the new git tag and `npm publish` (or `npm publish --tag next`) when you're ready.
 
+### Prevent Git Hooks
+
+If you use git hooks, like pre-commit, to test your code before committing, you can prevent hooks from being verified during the commit step by passing the `--no-verify` option:
+
+```sh
+# npm run script
+npm run release -- --no-verify
+# or global bin
+standard-version --no-verify
+```
+
 ### CLI Help
 
 ```sh

--- a/index.js
+++ b/index.js
@@ -108,12 +108,13 @@ function outputChangelog (argv, cb) {
 function commit (argv, newVersion, cb) {
   var msg = 'committing %s'
   var args = [argv.infile]
+  var verify = argv.verify === false ? '--no-verify ' : ''
   if (!argv.firstRelease) {
     msg += ' and %s'
     args.unshift('package.json')
   }
   checkpoint(msg, args)
-  exec('git add package.json ' + argv.infile + ';git commit ' + (argv.sign ? '-S ' : '') + 'package.json ' + argv.infile + ' -m "' + formatCommitMessage(argv.message, newVersion) + '"', function (err, stdout, stderr) {
+  exec('git add package.json ' + argv.infile + ';git commit ' + verify + (argv.sign ? '-S ' : '') + 'package.json ' + argv.infile + ' -m "' + formatCommitMessage(argv.message, newVersion) + '"', function (err, stdout, stderr) {
     var errMessage = null
     if (err) errMessage = err.message
     if (stderr) errMessage = stderr

--- a/index.js
+++ b/index.js
@@ -31,6 +31,13 @@ var argv = require('yargs')
     default: false,
     global: true
   })
+  .option('no-verify', {
+    alias: 'n',
+    describe: 'Bypass pre-commit or commit-msg git hooks during the commit phase',
+    type: 'boolean',
+    default: false,
+    global: true
+  })
   .help()
   .alias('help', 'h')
   .example('$0', 'Update changelog and tag release')

--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ function outputChangelog (argv, cb) {
 function commit (argv, newVersion, cb) {
   var msg = 'committing %s'
   var args = [argv.infile]
-  var verify = argv.verify === false ? '--no-verify ' : ''
+  var verify = argv.verify === false || argv.n ? '--no-verify ' : ''
   if (!argv.firstRelease) {
     msg += ' and %s'
     args.unshift('package.json')

--- a/test.js
+++ b/test.js
@@ -20,6 +20,11 @@ function writePackageJson (version) {
   }), 'utf-8')
 }
 
+function writeGitPreCommitHook () {
+  fs.writeFileSync('.git/hooks/pre-commit', '#!/bin/sh\necho "precommit ran"\nexit 1', 'utf-8')
+  fs.chmodSync('.git/hooks/pre-commit', '755')
+}
+
 describe('cli', function () {
   beforeEach(function () {
     shell.rm('-rf', 'tmp')
@@ -163,5 +168,13 @@ describe('cli', function () {
 
     var pkgJson = fs.readFileSync('package.json', 'utf-8')
     pkgJson.should.equal(['{', '  "version": "1.0.1"', '}', ''].join('\n'))
+  })
+
+  it('does not run git hooks if the --no-verify flag is passed', function () {
+    writePackageJson('1.0.0')
+    writeGitPreCommitHook()
+
+    commit('feat: first commit')
+    shell.exec(cliPath + ' --no-verify').code.should.equal(0)
   })
 })

--- a/test.js
+++ b/test.js
@@ -176,5 +176,7 @@ describe('cli', function () {
 
     commit('feat: first commit')
     shell.exec(cliPath + ' --no-verify').code.should.equal(0)
+    commit('feat: second commit')
+    shell.exec(cliPath + ' -n').code.should.equal(0)
   })
 })


### PR DESCRIPTION
Thanks for the awesome tool! We use a git pre-commit hook to test our code before committing and it seems to prevent the last step of standard-version (git tag). This PR adds a --no-verify option to disable git hook verification.