### PR TITLE
chore: add appveyor ci configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+environment:
+  matrix:
+    - nodejs_version: '6'
+    - nodejs_version: '5'
+    - nodejs_version: '4'
+    - nodejs_version: '0.12'
+    - nodejs_version: '0.10'
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - set CI=true
+  - npm -g install npm@latest
+  - set PATH=%APPDATA%\npm;%PATH%
+  - npm install
+matrix:
+  fast_finish: true
+build: off
+version: '{build}'
+test_script:
+  - node --version
+  - npm --version
+  - npm test


### PR DESCRIPTION
I added ci.appveyor.com to this project. Not much changed since #57, removed the `core.autocrlf = true` config. Is there any need for it really?