### PR TITLE
chore(deps): drop unused conventional-changelog-angular dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "conventional-changelog": "^1.1.0",
-    "conventional-changelog-angular": "^1.1.0",
     "conventional-recommended-bump": "^0.2.1",
     "figures": "^1.5.0",
     "fs-access": "^1.0.0",


### PR DESCRIPTION
It still remains in the dependency tree, but apparently it's not used explicitly by `standard-version`. Let's drop from package.json. (Thanks to [`npm-check`](https://github.com/dylang/npm-check) for this one.)