### PR TITLE
feat(changelogStream): use more default opts

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,11 +90,7 @@ function outputChangelog (argv, cb) {
   }
   var content = ''
   var changelogStream = conventionalChangelog({
-    preset: 'angular',
-    outputUnreleased: true,
-    pkg: {
-      path: path.resolve(process.cwd(), './package.json')
-    }
+    preset: 'angular'
   })
   .on('error', function (err) {
     console.error(chalk.red(err.message))


### PR DESCRIPTION
`pkg.path` defaults to the closest package.json (https://github.com/conventional-changelog/conventional-changelog-core#path), which is the same as `npm-version`.
`outputUnreleased` does not do anything to this module.