### PR TITLE
feat: preset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,17 @@ _but wait, there's more!_
 Github usernames (`@bcoe`) and issue references (#133) will be swapped out for the
 appropriate URLs in your CHANGELOG.
 
+### Preset
+
+To generate your changelog with a different message format preset, simply use:
+
+```sh
+standard-version --preset atom
+```
+
+You can use as the same preset names as in
+[conventional-changelog](https://github.com/conventional-changelog/conventional-changelog)
+
 ## Badges!
 
 Tell your users that you adhere to the `standard-version` commit guidelines:

--- a/index.js
+++ b/index.js
@@ -24,6 +24,13 @@ var argv = require('yargs')
     default: false,
     global: true
   })
+  .option('preset', {
+    alias: 'p',
+    describe: 'Which commit message format do you use?',
+    type: 'string',
+    default: 'angular',
+    global: true
+  })
   .option('sign', {
     alias: 's',
     describe: 'Should the git commit and tag be signed?',
@@ -55,8 +62,10 @@ var pkg = require(pkgPath)
 var semver = require('semver')
 var util = require('util')
 
+checkpoint('Using preset %s', [argv.preset])
+
 conventionalRecommendedBump({
-  preset: 'angular'
+  preset: argv.preset
 }, function (err, release) {
   if (err) {
     console.error(chalk.red(err.message))
@@ -90,7 +99,7 @@ function outputChangelog (argv, cb) {
   }
   var content = ''
   var changelogStream = conventionalChangelog({
-    preset: 'angular'
+    preset: argv.preset
   })
   .on('error', function (err) {
     console.error(chalk.red(err.message))

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "standard"
   ],
   "author": "Ben Coe <ben@npmjs.com>",
+  "contributors": [
+    {"name":"Andrej Zachar <andrej@chocolatejar.eu>"}
+  ],
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/conventional-changelog/standard-version/issues"

--- a/test.js
+++ b/test.js
@@ -71,6 +71,19 @@ describe('cli', function () {
       content.should.match(/first commit/)
       shell.exec('git tag').stdout.should.match(/1\.0\.1/)
     })
+
+    it('can use atom present', function () {
+      writePackageJson('1.0.2')
+
+      commit(':bug: atom message')
+      commit(':fix: critical bug')
+      commit(':fix: critical bug')
+      execCli('--preset atom').code.should.equal(0)
+
+      var content = fs.readFileSync('CHANGELOG.md', 'utf-8')
+      content.should.match(/atom message/)
+      shell.exec('git tag').stdout.should.match(/1\.0\.2/)
+    })
   })
 
   describe('CHANGELOG.md exists', function () {


### PR DESCRIPTION
Hi there, 

I implemented support for the preset parameters. Now you can specify the param --preset that is passed to  ``conventional-changelog``

For some reason, I've got stuck. The ``require`` cannot find ``conventional-changelog-<<name>>`` in ``conventional-changelog`` module.

What do you suggest to fix it?

For instance, do I need to install the module ``conventional-changelog-atom`` as a global dependency?


Thanks for your reply.

Cheers,
Andrej




