### PR TITLE
Don't fail on stderr output, but print the output to stderr

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,6 +108,17 @@ function outputChangelog (argv, cb) {
   })
 }
 
+function handleExecError (err, stderr) {
+  // If exec returns an error or content in stderr, log it and exit with return code 1
+  var errMessage = stderr || (err && err.message)
+  if (errMessage) {
+    console.error(chalk.red(errMessage))
+    if (err) {
+      process.exit(1)
+    }
+  }
+}
+
 function commit (argv, newVersion, cb) {
   var msg = 'committing %s'
   var args = [argv.infile]
@@ -118,14 +129,6 @@ function commit (argv, newVersion, cb) {
   }
   checkpoint(msg, args)
 
-  function handleExecError (err, stderr) {
-    // If exec returns an error or content in stderr, log it and exit with return code 1
-    var errMessage = stderr || (err && err.message)
-    if (errMessage) {
-      console.log(chalk.red(errMessage))
-      process.exit(1)
-    }
-  }
   exec('git add package.json ' + argv.infile, function (err, stdout, stderr) {
     handleExecError(err, stderr)
     exec('git commit ' + verify + (argv.sign ? '-S ' : '') + 'package.json ' + argv.infile + ' -m "' + formatCommitMessage(argv.message, newVersion) + '"', function (err, stdout, stderr) {
@@ -148,17 +151,11 @@ function tag (newVersion, argv) {
   }
   checkpoint('tagging release %s', [newVersion])
   exec('git tag ' + tagOption + 'v' + newVersion + ' -m "' + formatCommitMessage(argv.message, newVersion) + '"', function (err, stdout, stderr) {
+    handleExecError(err, stderr)
     var message = 'git push --follow-tags origin master'
-    var errMessage = null
-    if (err) errMessage = err.message
-    if (stderr) errMessage = stderr
     if (pkg.private !== true) message += '; npm publish'
-    if (errMessage) {
-      console.log(chalk.red(errMessage))
-      process.exit(1)
-    } else {
-      checkpoint('Run `%s` to publish', [message], chalk.blue(figures.info))
-    }
+
+    checkpoint('Run `%s` to publish', [message], chalk.blue(figures.info))
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -109,10 +109,11 @@ function outputChangelog (argv, cb) {
 }
 
 function handleExecError (err, stderr) {
-  // If exec returns an error or content in stderr, log it and exit with return code 1
+  // If exec returns content in stderr, but no error, print it as a warning
+  // If exec returns an error, print it and exit with return code 1
   var errMessage = stderr || (err && err.message)
   if (errMessage) {
-    console.error(chalk.red(errMessage))
+    console.error(err ? chalk.red(errMessage) : chalk.yellow(errMessage))
     if (err) {
       process.exit(1)
     }

--- a/index.js
+++ b/index.js
@@ -111,12 +111,11 @@ function outputChangelog (argv, cb) {
 function handleExecError (err, stderr) {
   // If exec returns content in stderr, but no error, print it as a warning
   // If exec returns an error, print it and exit with return code 1
-  var errMessage = stderr || (err && err.message)
-  if (errMessage) {
-    console.error(err ? chalk.red(errMessage) : chalk.yellow(errMessage))
-    if (err) {
-      process.exit(1)
-    }
+  if (err) {
+    console.error(chalk.red(stderr || err.message))
+    process.exit(1)
+  } else if (stderr) {
+    console.warn(chalk.yellow(stderr))
   }
 }
 

--- a/test.js
+++ b/test.js
@@ -117,7 +117,7 @@ describe('cli', function () {
 
           var result = execCli()
           result.code.should.equal(1)
-          result.stdout.should.match(/commit yourself/)
+          result.stderr.should.match(/commit yourself/)
 
           unmock()
         })
@@ -131,7 +131,7 @@ describe('cli', function () {
 
           var result = execCli()
           result.code.should.equal(1)
-          result.stdout.should.match(/addition is hard/)
+          result.stderr.should.match(/addition is hard/)
 
           unmock()
         })
@@ -145,7 +145,21 @@ describe('cli', function () {
 
           var result = execCli()
           result.code.should.equal(1)
-          result.stdout.should.match(/tag, you're it/)
+          result.stderr.should.match(/tag, you're it/)
+
+          unmock()
+        })
+    })
+
+    it('doesn\'t fail fast on stderr output from git', function () {
+      // mock git by throwing on attempt to commit
+      return mockGit('console.error("haha, kidding, this is just a warning"); process.exit(0);', 'add')
+        .then(function (unmock) {
+          writePackageJson('1.0.0')
+
+          var result = execCli()
+          result.code.should.equal(0)
+          result.stderr.should.match(/haha, kidding, this is just a warning/)
 
           unmock()
         })


### PR DESCRIPTION
For #91, this would stop `standard-version` from failing fast when `git` or hooks or something prints to `stderr`, but prints it out. Added test case it for as well. Also, errors are now printed to `stderr/console.error` instead of `stdout/console.log`.

/CC @nexdrew @duclet @e-cloud @stevemao @bcoe