### PR TITLE
Restructuring for 100% test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "5"
   - "node"

--- a/README.md
+++ b/README.md
@@ -122,13 +122,17 @@ standard-version --help
 
 ## Code usage
 
+Use the `silent` option to stop `standard-version` from printing anything
+to the console.
+
 ```js
 var standardVersion = require('standard-version')
 
 // Options are the same as command line, except camelCase
 standardVersion({
   noVerify: true,
-  infile: 'docs/CHANGELOG.md'
+  infile: 'docs/CHANGELOG.md',
+  silent: true
 }, function (err) {
   if (err) {
     console.error(`standard-version failed with message: ${err.message}`)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Now you can use `standard-version` in place of `npm version`.
 
 This has the benefit of allowing you to use `standard-version` on any repo/package without adding a dev dependency to each one.
 
-## Usage
+## CLI Usage
 
 ### First Release
 
@@ -118,6 +118,23 @@ If you have your GPG key set up, add the `--sign` or `-s` flag to your `standard
 npm run release -- --help
 # or global bin
 standard-version --help
+```
+
+## Code usage
+
+```js
+var standardVersion = require('standard-version')
+
+// Options are the same as command line, except camelCase
+standardVersion({
+  noVerify: true,
+  infile: 'docs/CHANGELOG.md'
+}, function (err) {
+  if (err) {
+    console.error(`standard-version failed with message: ${err.message}`)
+  }
+  // standard-version is done
+})
 ```
 
 ## Commit Message Convention, at a Glance

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ environment:
     - nodejs_version: '6'
     - nodejs_version: '5'
     - nodejs_version: '4'
-    - nodejs_version: '0.12'
 install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+var standardVersion = require('./index')
+var defaults = require('./defaults')
+
+var argv = require('yargs')
+  .usage('Usage: $0 [options]')
+  .option('infile', {
+    alias: 'i',
+    describe: 'Read the CHANGELOG from this file',
+    default: defaults.infile,
+    global: true
+  })
+  .option('message', {
+    alias: 'm',
+    describe: 'Commit message, replaces %s with new version',
+    type: 'string',
+    default: defaults.message,
+    global: true
+  })
+  .option('first-release', {
+    alias: 'f',
+    describe: 'Is this the first release?',
+    type: 'boolean',
+    default: defaults.firstRelease,
+    global: true
+  })
+  .option('sign', {
+    alias: 's',
+    describe: 'Should the git commit and tag be signed?',
+    type: 'boolean',
+    default: defaults.sign,
+    global: true
+  })
+  .option('no-verify', {
+    alias: 'n',
+    describe: 'Bypass pre-commit or commit-msg git hooks during the commit phase',
+    type: 'boolean',
+    default: defaults.noVerify,
+    global: true
+  })
+  .help()
+  .alias('help', 'h')
+  .example('$0', 'Update changelog and tag release')
+  .example('$0 -m "%s: see changelog for details"', 'Update changelog and tag release with custom commit message')
+  .wrap(97)
+  .argv
+
+standardVersion(argv, function (err) {
+  if (err) {
+    process.exit(1)
+  }
+})

--- a/cli.js
+++ b/cli.js
@@ -38,6 +38,12 @@ var argv = require('yargs')
     default: defaults.noVerify,
     global: true
   })
+  .option('silent', {
+    describe: 'Don\'t print logs and errors',
+    type: 'boolean',
+    default: defaults.silent,
+    global: true
+  })
   .help()
   .alias('help', 'h')
   .example('$0', 'Update changelog and tag release')

--- a/defaults.json
+++ b/defaults.json
@@ -1,0 +1,7 @@
+{
+  "infile": "CHANGELOG.md",
+  "message": "chore(release): %s",
+  "firstRelease": false,
+  "sign": false,
+  "noVerify": false,
+}

--- a/defaults.json
+++ b/defaults.json
@@ -4,4 +4,5 @@
   "firstRelease": false,
   "sign": false,
   "noVerify": false,
+  "silent": false
 }

--- a/index.js
+++ b/index.js
@@ -143,16 +143,20 @@ function createIfMissing (argv) {
 }
 
 function checkpoint (argv, msg, args, figure) {
-  console.info((figure || chalk.green(figures.tick)) + ' ' + util.format.apply(util, [msg].concat(args.map(function (arg) {
-    return chalk.bold(arg)
-  }))))
+  if (!argv.silent) {
+    console.info((figure || chalk.green(figures.tick)) + ' ' + util.format.apply(util, [msg].concat(args.map(function (arg) {
+      return chalk.bold(arg)
+    }))))
+  }
 }
 
 function printError (argv, msg, opts) {
-  opts = objectAssign({
-    level: 'error',
-    color: 'red'
-  }, opts)
+  if (!argv.silent) {
+    opts = objectAssign({
+      level: 'error',
+      color: 'red'
+    }, opts)
 
-  console[opts.level](chalk[opts.color](msg))
+    console[opts.level](chalk[opts.color](msg))
+  }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "coveralls": "^2.11.9",
     "mocha": "^3.0.1",
     "mock-git": "^1.0.2",
+    "mockery": "^1.7.0",
     "nyc": "^8.1.0",
     "shelljs": "^0.7.3",
     "standard": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git+https://github.com/conventional-changelog/standard-version.git"
   },
+  "engines": {
+    "node" : ">=4.0"
+  },
   "keywords": [
     "conventional-changelog",
     "recommended",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "standard-version",
   "version": "2.4.0",
   "description": "replacement for `npm version` with automatic CHANGELOG generation",
-  "bin": "index.js",
+  "bin": "cli.js",
   "scripts": {
     "pretest": "standard",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
@@ -37,6 +37,7 @@
     "conventional-recommended-bump": "^0.3.0",
     "figures": "^1.5.0",
     "fs-access": "^1.0.0",
+    "object-assign": "^4.1.0",
     "semver": "^5.1.0",
     "yargs": "^5.0.0"
   },

--- a/test.js
+++ b/test.js
@@ -199,6 +199,13 @@ describe('cli', function () {
     execCli('-n').code.should.equal(0)
   })
 
+  it('does not print output when the --silent flag is passed', function () {
+    var result = execCli('--silent')
+    result.code.should.equal(0)
+    result.stdout.should.equal('')
+    result.stderr.should.equal('')
+  })
+
   it('does not display `npm publish` if the package is private', function () {
     writePackageJson('1.0.0', {private: true})
 


### PR DESCRIPTION
This might be a bit much, but actually nice in the long run. So the only parts that weren't being tested previously were `conventionalChangelog` and `conventionalRecommendedBump` error handling. The problem with handling them was that the `cli` was being called with shell execution, so mocking was nigh impossible. As a result, I did some restructuring:

* Separated the `cli` into `cli.js`
* `standard-version` actual logic in `index.js` with `module.exports` being a function
    * This allows `standard-version` to be used by other tools, tests etc.
    * Usage: `require('standard-version')(opts, callback)`
    * `opts` is an object with `cli` options in camelcase, e.g. `{firstRelease: true}`
    * `callback` will be called with possible error when `standard-version` is done (see `cli.js`)
* Separated default options into `defaults.json`, so they can be at one place instead of both `index.js` and `cli.js` (needed in `cli.js` for `yargs` help messages)
* Wrote tests for `conventionalChangelog` and `conventionalRecommendedBump` error situations
    * Mocked with [`mockery`](https://github.com/mfncooper/mockery)
* Added `silent` option to skip logging to console, also added to the `cli` (needed in tests that use `index.js` directly)

Long list of small changes all related, needed to get test coverage to 100%. I think the structure is nice, but the interface could probably actually be an event emitter or generator that emits events at checkpoints. Then the `cli` could log those checkpoints and the silent option wouldn't actually be needed in `index.js`. Just an idea, but that would separate logic that's always wanted and logic that's `cli` specific.

I'll work on working these into sensible commits with messages once theres some discussion about it, but that shouldn't take very long.

/CC @bcoe @stevemao @nexdrew 