### PR TITLE
feat: added support for commitAll option in CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -38,6 +38,13 @@ var argv = require('yargs')
     default: defaults.noVerify,
     global: true
   })
+  .option('commit-all', {
+    alias: 'a',
+    describe: 'Commit all staged changes, not just files affected by standard-version',
+    type: 'boolean',
+    default: defaults.commitAll,
+    global: true
+  })
   .option('silent', {
     describe: 'Don\'t print logs and errors',
     type: 'boolean',

--- a/defaults.json
+++ b/defaults.json
@@ -4,5 +4,6 @@
   "firstRelease": false,
   "sign": false,
   "noVerify": false,
+  "commitAll": false,
   "silent": false
 }

--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ function outputChangelog (argv, cb) {
 
 function handledExec (argv, cmd, errorCb, successCb) {
   // Exec given cmd and handle possible errors
+
   exec(cmd, function (err, stdout, stderr) {
     // If exec returns content in stderr, but no error, print it as a warning
     // If exec returns an error, print it and exit with return code 1
@@ -101,9 +102,8 @@ function commit (argv, newVersion, cb) {
     args.unshift('package.json')
   }
   checkpoint(argv, msg, args)
-
   handledExec(argv, 'git add package.json ' + argv.infile, cb, function () {
-    handledExec(argv, 'git commit ' + verify + (argv.sign ? '-S ' : '') + 'package.json ' + argv.infile + ' -m "' + formatCommitMessage(argv.message, newVersion) + '"', cb, function () {
+    handledExec(argv, 'git commit ' + verify + (argv.sign ? '-S ' : '') + (argv.commitAll ? '' : ('package.json ' + argv.infile)) + ' -m "' + formatCommitMessage(argv.message, newVersion) + '"', cb, function () {
       cb()
     })
   })

--- a/test.js
+++ b/test.js
@@ -92,6 +92,29 @@ describe('cli', function () {
       content.should.match(/1\.0\.1/)
       content.should.not.match(/legacy header format/)
     })
+
+    it('commits all staged files', function () {
+      fs.writeFileSync('CHANGELOG.md', 'legacy header format<a name="1.0.0">\n', 'utf-8')
+
+      commit('feat: first commit')
+      shell.exec('git tag -a v1.0.0 -m "my awesome first release"')
+      commit('fix: patch release')
+
+      fs.writeFileSync('STUFF.md', 'stuff\n', 'utf-8')
+
+      shell.exec('git add STUFF.md')
+
+      execCli('--commit-all').code.should.equal(0)
+
+      var content = fs.readFileSync('CHANGELOG.md', 'utf-8')
+      var status = shell.exec('git status')
+
+      status.should.match(/On branch master\nnothing to commit, working directory clean\n/)
+      status.should.not.match(/STUFF.md/)
+
+      content.should.match(/1\.0\.1/)
+      content.should.not.match(/legacy header format/)
+    })
   })
 
   describe('with mocked git', function () {


### PR DESCRIPTION
npm version will commit any staged files as part of it's execution.  This feature adds the option to support that in build server scenarios where a build step needs to commit other files besides just package & changelog.  the default behavior is preserved, so this is an opt in feature.