### PR TITLE
fix: include merge commits in the changelog

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function outputChangelog (argv, cb) {
   var content = ''
   var changelogStream = conventionalChangelog({
     preset: 'angular'
-  })
+  }, undefined, {merges: null})
     .on('error', function (err) {
       return cb(err)
     })


### PR DESCRIPTION
By passing `merges: null` to the conventional-changelog function the default "--no-merges" git CLI argument is removed, and therefore both normal and merge commits are returned from the log for processing.
Note that setting it to `true` would have changed "--no-merges" to "--merges", causing _only_ merges to be retrieved from the log.

Fixes #137 