### PR TITLE
fix: support a wording change made to git status in git v2.9.1

### DIFF
--- a/test.js
+++ b/test.js
@@ -109,7 +109,7 @@ describe('cli', function () {
       var content = fs.readFileSync('CHANGELOG.md', 'utf-8')
       var status = shell.exec('git status')
 
-      status.should.match(/On branch master\nnothing to commit, working directory clean\n/)
+      status.should.match(/On branch master\nnothing to commit, working (directory|tree) clean\n/)
       status.should.not.match(/STUFF.md/)
 
       content.should.match(/1\.0\.1/)


### PR DESCRIPTION
Simply changed the assertion regex of the "commits all staged files" unit test to support a wording change made to git status in git v2.9.1 from _"working directory"_ to _"working tree"_

See:
https://github.com/git/git/commit/2a0e6cdedab306eccbd297c051035c13d0266343

Fixes #138 