### PR TITLE
feat: make tagPrefix configurable

### DIFF
--- a/command.js
+++ b/command.js
@@ -66,7 +66,7 @@ module.exports = require('yargs')
   .option('tag-prefix', {
     alias: 't',
     describe: 'Set a custom prefix for the git tag to be created',
-    type: 'boolean',
+    type: 'string',
     default: defaults.tagPrefix,
     global: true
   })

--- a/command.js
+++ b/command.js
@@ -63,6 +63,13 @@ module.exports = require('yargs')
     default: defaults.silent,
     global: true
   })
+  .option('tag-prefix', {
+    alias: 't',
+    describe: 'Set a custom prefix for the git tag to be created',
+    type: 'boolean',
+    default: defaults.tagPrefix,
+    global: true
+  })
   .version()
   .alias('version', 'v')
   .help()

--- a/defaults.json
+++ b/defaults.json
@@ -5,5 +5,6 @@
   "sign": false,
   "noVerify": false,
   "commitAll": false,
-  "silent": false
+  "silent": false,
+  "tagPrefix": "v"
 }

--- a/index.js
+++ b/index.js
@@ -203,7 +203,7 @@ function tag (newVersion, pkgPrivate, argv, cb) {
     tagOption = '-a '
   }
   checkpoint(argv, 'tagging release %s', [newVersion])
-  handledExec(argv, 'git tag ' + tagOption + 'v' + newVersion + ' -m "' + formatCommitMessage(argv.message, newVersion) + '"', cb, function () {
+  handledExec(argv, 'git tag ' + tagOption + argv.tagPrefix + newVersion + ' -m "' + formatCommitMessage(argv.message, newVersion) + '"', cb, function () {
     var message = 'git push --follow-tags origin master'
     if (pkgPrivate !== true) message += '; npm publish'
 


### PR DESCRIPTION
At Aurelia we don't use any tag prefixes, our tags are just `1.0`, thus we couldn't use `standard-version` as is. Right now `standard-version` has a hardcoded `v` prefix for all the git tags for releases, i.e. `v1.0`, `v1.1`. This change makes it configurable so you can have no prefix or a custom prefix if you wish. I left the default `v` prefix, so this is a non-breaking change.