### PR TITLE
feat: add support for bumping version # in bower.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ _how it works:_
 
 `standard-version` does the following:
 
-1. bumps the version in _package.json_ (based on your commit history)
+1. bumps the version in _package.json/bower.json_ (based on your commit history)
 2. uses [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) to update _CHANGELOG.md_
-3. commits _package.json_ and _CHANGELOG.md_
+3. commits _package.json (et al.)_ and _CHANGELOG.md_
 4. tags a new release
 
 ## Installation
@@ -77,7 +77,7 @@ npm run release -- --first-release
 standard-version --first-release
 ```
 
-This will tag a release **without bumping the version in package.json**.
+This will tag a release **without bumping the version in package.json (_et al._)**.
 
 When ready, push the git tag and `npm publish` your first release. \o/
 

--- a/index.js
+++ b/index.js
@@ -13,10 +13,8 @@ var objectAssign = require('object-assign')
 
 module.exports = function standardVersion (argv, done) {
   var pkgPath = path.resolve(process.cwd(), './package.json')
-  var bowerPath = path.resolve(process.cwd(), './bower.json')
   var pkg = require(pkgPath)
   var defaults = require('./defaults')
-
   var args = objectAssign({}, defaults, argv)
 
   bumpVersion(args.releaseAs, function (err, release) {
@@ -30,20 +28,7 @@ module.exports = function standardVersion (argv, done) {
     if (!args.firstRelease) {
       var releaseType = getReleaseType(args.prerelease, release.releaseType, pkg.version)
       newVersion = semver.inc(pkg.version, releaseType, args.prerelease)
-
-      checkpoint(args, 'bumping version in package.json from %s to %s', [pkg.version, newVersion])
-
-      pkg.version = newVersion
-      fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n', 'utf-8')
-      try {
-        var stat = fs.lstatSync(bowerPath)
-        if (stat.isFile()) {
-          var bower = require(bowerPath)
-          bower.version = newVersion
-          fs.writeFileSync(bowerPath, JSON.stringify(bower, null, 2) + '\n', 'utf-8')
-          argv.bower = true
-        }
-      } catch (e) {}
+      updateConfigs(args, newVersion)
     } else {
       checkpoint(args, 'skip version bump on first release', [], chalk.red(figures.cross))
     }
@@ -59,6 +44,37 @@ module.exports = function standardVersion (argv, done) {
         return tag(newVersion, pkg.private, args, done)
       })
     })
+  })
+}
+
+/**
+ * attempt to update the version # in a collection of common config
+ * files, e.g., package.json, bower.json.
+ *
+ * @param argv config object
+ * @param newVersion version # to update to.
+ * @return {string}
+ */
+var configsToUpdate = {}
+function updateConfigs (args, newVersion) {
+  configsToUpdate[path.resolve(process.cwd(), './package.json')] = false
+  configsToUpdate[path.resolve(process.cwd(), './bower.json')] = false
+  Object.keys(configsToUpdate).forEach(function (configPath) {
+    try {
+      var stat = fs.lstatSync(configPath)
+      if (stat.isFile()) {
+        var config = require(configPath)
+        var filename = path.basename(configPath)
+        config.version = newVersion
+        fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8')
+        checkpoint(args, 'bumping version in ' + filename + ' from %s to %s', [config.version, newVersion])
+        // flag any config files that we modify the version # for
+        // as having been updated.
+        configsToUpdate[configPath] = true
+      }
+    } catch (err) {
+      if (err.code !== 'ENOENT') console.warn(err.message)
+    }
   })
 }
 
@@ -170,7 +186,6 @@ function outputChangelog (argv, cb) {
 
 function handledExec (argv, cmd, errorCb, successCb) {
   // Exec given cmd and handle possible errors
-
   exec(cmd, function (err, stdout, stderr) {
     // If exec returns content in stderr, but no error, print it as a warning
     // If exec returns an error, print it and exit with return code 1
@@ -188,19 +203,19 @@ function commit (argv, newVersion, cb) {
   var msg = 'committing %s'
   var args = [argv.infile]
   var verify = argv.verify === false || argv.n ? '--no-verify ' : ''
-  var bower = ''
-  if (!argv.firstRelease) {
-    msg += ' and %s'
-    args.unshift('package.json')
-  }
-  if (argv.bower) {
-    msg += ' and %s'
-    args.unshift('bower.json')
-    bower = ' bower.json'
-  }
+  var toAdd = ''
+  // commit any of the config files that we've updated
+  // the version # for.
+  Object.keys(configsToUpdate).forEach(function (p) {
+    if (configsToUpdate[p]) {
+      msg += ' and %s'
+      args.unshift(path.basename(p))
+      toAdd += ' ' + path.relative(process.cwd(), p)
+    }
+  })
   checkpoint(argv, msg, args)
-  handledExec(argv, 'git add package.json ' + argv.infile + bower, cb, function () {
-    handledExec(argv, 'git commit ' + verify + (argv.sign ? '-S ' : '') + (argv.commitAll ? '' : ('package.json ' + argv.infile + bower)) + ' -m "' + formatCommitMessage(argv.message, newVersion) + '"', cb, function () {
+  handledExec(argv, 'git add' + toAdd + ' ' + argv.infile, cb, function () {
+    handledExec(argv, 'git commit ' + verify + (argv.sign ? '-S ' : '') + (argv.commitAll ? '' : (argv.infile + toAdd)) + ' -m "' + formatCommitMessage(argv.message, newVersion) + '"', cb, function () {
       cb()
     })
   })

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ var objectAssign = require('object-assign')
 
 module.exports = function standardVersion (argv, done) {
   var pkgPath = path.resolve(process.cwd(), './package.json')
+  var bowerPath = path.resolve(process.cwd(), './bower.json')
   var pkg = require(pkgPath)
   var defaults = require('./defaults')
 
@@ -34,6 +35,15 @@ module.exports = function standardVersion (argv, done) {
 
       pkg.version = newVersion
       fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n', 'utf-8')
+      try {
+        var stat = fs.lstatSync(bowerPath)
+        if (stat.isFile()) {
+          var bower = require(bowerPath)
+          bower.version = newVersion
+          fs.writeFileSync(bowerPath, JSON.stringify(bower, null, 2) + '\n', 'utf-8')
+          argv.bower = true
+        }
+      } catch (e) {}
     } else {
       checkpoint(args, 'skip version bump on first release', [], chalk.red(figures.cross))
     }
@@ -178,14 +188,19 @@ function commit (argv, newVersion, cb) {
   var msg = 'committing %s'
   var args = [argv.infile]
   var verify = argv.verify === false || argv.n ? '--no-verify ' : ''
+  var bower = ''
   if (!argv.firstRelease) {
     msg += ' and %s'
     args.unshift('package.json')
   }
+  if (argv.bower) {
+    msg += ' and %s'
+    args.unshift('bower.json')
+    bower = ' bower.json'
+  }
   checkpoint(argv, msg, args)
-
-  handledExec(argv, 'git add package.json ' + argv.infile, cb, function () {
-    handledExec(argv, 'git commit ' + verify + (argv.sign ? '-S ' : '') + (argv.commitAll ? '' : ('package.json ' + argv.infile)) + ' -m "' + formatCommitMessage(argv.message, newVersion) + '"', cb, function () {
+  handledExec(argv, 'git add package.json ' + argv.infile + bower, cb, function () {
+    handledExec(argv, 'git commit ' + verify + (argv.sign ? '-S ' : '') + (argv.commitAll ? '' : ('package.json ' + argv.infile + bower)) + ' -m "' + formatCommitMessage(argv.message, newVersion) + '"', cb, function () {
       cb()
     })
   })

--- a/test.js
+++ b/test.js
@@ -49,6 +49,12 @@ function writePackageJson (version, option) {
   delete require.cache[require.resolve(path.join(process.cwd(), 'package.json'))]
 }
 
+function writeBowerJson (version, option) {
+  option = option || {}
+  var bower = objectAssign(option, { version: version })
+  fs.writeFileSync('bower.json', JSON.stringify(bower), 'utf-8')
+}
+
 function writeGitPreCommitHook () {
   fs.writeFileSync('.git/hooks/pre-commit', '#!/bin/sh\necho "precommit ran"\nexit 1', 'utf-8')
   fs.chmodSync('.git/hooks/pre-commit', '755')
@@ -460,6 +466,24 @@ describe('standard-version', function () {
       require('./index')({silent: true}, function (err) {
         should.exist(err)
         err.message.should.match(/changelog err/)
+        done()
+      })
+    })
+  })
+
+  describe('with bower.json', function () {
+    beforeEach(function () {
+      writeBowerJson('1.0.0')
+    })
+
+    it('check with bower.json', function (done) {
+      commit('feat: first commit')
+      shell.exec('git tag -a v1.0.0 -m "my awesome first release"')
+      commit('feat: new feature!')
+      require('./index')({silent: true}, function (err) {
+        should.not.exist(err)
+        var bower = fs.readFileSync('bower.json', 'utf-8')
+        bower.should.match(/"version": "1\.2\.0"/)
         done()
       })
     })

--- a/test.js
+++ b/test.js
@@ -471,24 +471,6 @@ describe('standard-version', function () {
     })
   })
 
-  describe('with bower.json', function () {
-    beforeEach(function () {
-      writeBowerJson('1.0.0')
-    })
-
-    it('check with bower.json', function (done) {
-      commit('feat: first commit')
-      shell.exec('git tag -a v1.0.0 -m "my awesome first release"')
-      commit('feat: new feature!')
-      require('./index')({silent: true}, function (err) {
-        if (err) return done(err)
-        JSON.parse(fs.readFileSync('package.json', 'utf-8')).version.should.equal('1.1.0')
-        getPackageVersion().should.equal('1.1.0')
-        done()
-      })
-    })
-  })
-
   it('formats the commit and tag messages appropriately', function (done) {
     commit('feat: first commit')
     shell.exec('git tag -a v1.0.0 -m "my awesome first release"')
@@ -502,6 +484,24 @@ describe('standard-version', function () {
       // check annotated tag message
       shell.exec('git tag -l -n1 v1.1.0').stdout.should.match(/chore\(release\): 1\.1\.0/)
       done()
+    })
+  })
+
+  describe('bower.json support', function () {
+    beforeEach(function () {
+      writeBowerJson('1.0.0')
+    })
+
+    it('bumps verson # in bower.json', function (done) {
+      commit('feat: first commit')
+      shell.exec('git tag -a v1.0.0 -m "my awesome first release"')
+      commit('feat: new feature!')
+      require('./index')({silent: true}, function (err) {
+        if (err) return done(err)
+        JSON.parse(fs.readFileSync('package.json', 'utf-8')).version.should.equal('1.1.0')
+        getPackageVersion().should.equal('1.1.0')
+        done()
+      })
     })
   })
 })

--- a/test.js
+++ b/test.js
@@ -158,7 +158,7 @@ describe('cli', function () {
           var captured = shell.cat('gitcapture.log').stdout.split('\n').map(function (line) {
             return line ? JSON.parse(line) : line
           })
-          captured[captured.length - 3].should.deep.equal(['commit', '-S', 'package.json', 'CHANGELOG.md', '-m', 'chore(release): 1.0.1'])
+          captured[captured.length - 3].should.deep.equal(['commit', '-S', 'CHANGELOG.md', 'package.json', '-m', 'chore(release): 1.0.1'])
           captured[captured.length - 2].should.deep.equal(['tag', '-s', 'v1.0.1', '-m', 'chore(release): 1.0.1'])
 
           unmock()
@@ -481,9 +481,9 @@ describe('standard-version', function () {
       shell.exec('git tag -a v1.0.0 -m "my awesome first release"')
       commit('feat: new feature!')
       require('./index')({silent: true}, function (err) {
-        should.not.exist(err)
-        var bower = fs.readFileSync('bower.json', 'utf-8')
-        bower.should.match(/"version": "1\.2\.0"/)
+        if (err) return done(err)
+        JSON.parse(fs.readFileSync('package.json', 'utf-8')).version.should.equal('1.1.0')
+        getPackageVersion().should.equal('1.1.0')
         done()
       })
     })


### PR DESCRIPTION
working from @lexich's foundation, this pull adds support for bumping version # in multiple config files in a generic way.