### PR TITLE
fix: add '-a' option to git commit command to actually commit all fil…

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,7 +215,7 @@ function commit (argv, newVersion, cb) {
   })
   checkpoint(argv, msg, args)
   handledExec(argv, 'git add' + toAdd + ' ' + argv.infile, cb, function () {
-    handledExec(argv, 'git commit ' + verify + (argv.sign ? '-S ' : '') + (argv.commitAll ? '' : (argv.infile + toAdd)) + ' -m "' + formatCommitMessage(argv.message, newVersion) + '"', cb, function () {
+    handledExec(argv, 'git commit ' + verify + (argv.sign ? '-S ' : '') + (argv.commitAll ? ' -a ' : (argv.infile + toAdd)) + ' -m "' + formatCommitMessage(argv.message, newVersion) + '"', cb, function () {
       cb()
     })
   })


### PR DESCRIPTION
…es when commitAll option is true. Closes #166