### PR TITLE
feat(cli): Add a new context flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ If you want to commit generated artifacts in the release commit (e.g. [#96](http
 ### Use a specific context
 
 If you want to use a specific context, you can use `--context <file.json>` or `-c  <file.json>`
+For example, if you use a private version control system installed locally as gitlab, and your url does not contain the gitlab keyword (http:://myprivaterepo.company.com). It is mandatory to inform manually 'standard-version' on the context to be used.
 
 Example `gitlab.json` :
 ```json

--- a/README.md
+++ b/README.md
@@ -159,6 +159,31 @@ If you want to commit generated artifacts in the release commit (e.g. [#96](http
 "release": "git add <file(s) to commit> && standard-version -a"
 ```
 
+### Use a specific context
+
+If you want to use a specific context, you can use `--context <file.json>` or `-c  <file.json>`
+
+Example `gitlab.json` :
+```json
+{
+  "issue": "issues",
+  "commit": "commit",
+  "referenceActions": [
+   "close",
+   "closes",
+   "closed",
+   "closing",
+   "fix",
+   "fixes",
+   "fixed",
+   "fixing"
+ ],
+ "issuePrefixes": [
+   "#"
+ ]
+}
+```
+
 ### CLI Help
 
 ```sh

--- a/command.js
+++ b/command.js
@@ -59,7 +59,7 @@ module.exports = require('yargs')
   })
   .option('context', {
     alias: 'c',
-    describe: 'A filepath of a json that is used to define template variables',
+    describe: 'A filepath of a json file that is used to define template variables',
     type: 'string',
     default: undefined,
     global: true

--- a/command.js
+++ b/command.js
@@ -57,6 +57,13 @@ module.exports = require('yargs')
     default: defaults.commitAll,
     global: true
   })
+  .option('context', {
+    alias: 'c',
+    describe: 'A filepath of a json that is used to define template variables',
+    type: 'string',
+    default: undefined,
+    global: true
+  })
   .option('silent', {
     describe: 'Don\'t print logs and errors',
     type: 'boolean',

--- a/context.json
+++ b/context.json
@@ -1,0 +1,5 @@
+{
+  "host": "bitbucket",
+  "owner": "b",
+  "repository": "a"
+}

--- a/index.js
+++ b/index.js
@@ -158,6 +158,10 @@ function bumpVersion (releaseAs, callback) {
 }
 
 function outputChangelog (argv, cb) {
+  var templateContext
+  if (argv.context) {
+    templateContext = require(path.resolve(process.cwd(), argv.context))
+  }
   createIfMissing(argv)
   var header = '# Change Log\n\nAll notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.\n'
   var oldContent = fs.readFileSync(argv.infile, 'utf-8')
@@ -168,7 +172,7 @@ function outputChangelog (argv, cb) {
   var content = ''
   var changelogStream = conventionalChangelog({
     preset: 'angular'
-  }, undefined, {merges: null})
+  }, templateContext, {merges: null})
     .on('error', function (err) {
       return cb(err)
     })

--- a/test.js
+++ b/test.js
@@ -216,6 +216,22 @@ describe('cli', function () {
     })
   })
 
+  describe('with context', function () {
+    it('should use context.json', function () {
+      writePackageJson('1.0.1')
+
+      commit('feat: new context flag')
+      commit('fix: patch release')
+      execCli('--context ../context.json').code.should.equal(0)
+
+      var content = fs.readFileSync('CHANGELOG.md', 'utf-8')
+      content.should.include('](bitbucket/b/a/commits/')
+      content.should.match(/patch release/)
+      content.should.match(/new context flag/)
+      shell.exec('git tag').stdout.should.match(/1\.1\.0/)
+    })
+  })
+
   describe('pre-release', function () {
     it('works fine without specifying a tag id when prereleasing', function () {
       writePackageJson('1.0.0')


### PR DESCRIPTION
Running standard-version with the flag --context or -c allows you to specify a different host context.
```sh
# npm run script
npm run release -- --context <context.json>
# or global bin
standard-version --context <context.json>
```
In case you are using a private version control system installed locally like gitlab, and your repository url does not contain the git type keyword (github|bitbucket|gitlab). It is mandatory to inform manually standard-version on the host context (keywords) to be used.

package.json :
```json
{
  "name": "Private Project",
  "author": "Private Owner",
  "version": "1.0.0",
  "repository": "http:://private-repo.company.org/private-owner/private-project.git"
}
```
gitlab.json :
```json
{
  "issue": "issues",
  "commit": "commit",
  "referenceActions": [
   "close",
   "closes",
   "closed",
   "closing",
   "fix",
   "fixes",
   "fixed",
   "fixing"
 ],
 "issuePrefixes": [
   "#"
 ]
}
```