### PR TITLE
feat: add support for `npm-shrinkwrap.json`

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ module.exports = function standardVersion (argv, done) {
 var configsToUpdate = {}
 function updateConfigs (args, newVersion) {
   configsToUpdate[path.resolve(process.cwd(), './package.json')] = false
+  configsToUpdate[path.resolve(process.cwd(), './npm-shrinkwrap.json')] = false
   configsToUpdate[path.resolve(process.cwd(), './bower.json')] = false
   Object.keys(configsToUpdate).forEach(function (configPath) {
     try {

--- a/test.js
+++ b/test.js
@@ -538,7 +538,7 @@ describe('standard-version', function () {
       })
     })
   })
-  
+
   describe('npm-shrinkwrap.json support', function () {
     beforeEach(function () {
       writeNpmShrinkwrapJson('1.0.0')

--- a/test.js
+++ b/test.js
@@ -55,6 +55,12 @@ function writeBowerJson (version, option) {
   fs.writeFileSync('bower.json', JSON.stringify(bower), 'utf-8')
 }
 
+function writeNpmShrinkwrapJson (version, option) {
+  option = option || {}
+  var shrinkwrap = objectAssign(option, { version: version })
+  fs.writeFileSync('npm-shrinkwrap.json', JSON.stringify(shrinkwrap), 'utf-8')
+}
+
 function writeGitPreCommitHook () {
   fs.writeFileSync('.git/hooks/pre-commit', '#!/bin/sh\necho "precommit ran"\nexit 1', 'utf-8')
   fs.chmodSync('.git/hooks/pre-commit', '755')
@@ -520,13 +526,31 @@ describe('standard-version', function () {
       writeBowerJson('1.0.0')
     })
 
-    it('bumps verson # in bower.json', function (done) {
+    it('bumps version # in bower.json', function (done) {
       commit('feat: first commit')
       shell.exec('git tag -a v1.0.0 -m "my awesome first release"')
       commit('feat: new feature!')
       require('./index')({silent: true}, function (err) {
         if (err) return done(err)
-        JSON.parse(fs.readFileSync('package.json', 'utf-8')).version.should.equal('1.1.0')
+        JSON.parse(fs.readFileSync('bower.json', 'utf-8')).version.should.equal('1.1.0')
+        getPackageVersion().should.equal('1.1.0')
+        done()
+      })
+    })
+  })
+  
+  describe('npm-shrinkwrap.json support', function () {
+    beforeEach(function () {
+      writeNpmShrinkwrapJson('1.0.0')
+    })
+
+    it('bumps version # in npm-shrinkwrap.json', function (done) {
+      commit('feat: first commit')
+      shell.exec('git tag -a v1.0.0 -m "my awesome first release"')
+      commit('feat: new feature!')
+      require('./index')({silent: true}, function (err) {
+        if (err) return done(err)
+        JSON.parse(fs.readFileSync('npm-shrinkwrap.json', 'utf-8')).version.should.equal('1.1.0')
         getPackageVersion().should.equal('1.1.0')
         done()
       })


### PR DESCRIPTION
Hi, I use your module since a few weeks, and as I missed this little feature, here it is.
By the way, I fixed the bower test since it didn't check the `bower.json` file. :smile: 
Thank for your great work.
Aurélien