### PR TITLE
feat: add dry-run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,18 @@ If you want to commit generated artifacts in the release commit (e.g. [#96](http
 "release": "git add <file(s) to commit> && standard-version -a"
 ```
 
+### Dry run mode
+
+running `standard-version` with the flag `--dry-run` allows you to see what
+commands would be run, without committing to git or updating files.
+
+```sh
+# npm run script
+npm run release -- --dry-run
+# or global bin
+standard-version --dry-run
+```
+
 ### CLI Help
 
 ```sh

--- a/command.js
+++ b/command.js
@@ -6,76 +6,70 @@ module.exports = require('yargs')
     alias: 'r',
     describe: 'Specify the release type manually (like npm version <major|minor|patch>)',
     requiresArg: true,
-    string: true,
-    global: true
+    string: true
   })
   .option('prerelease', {
     alias: 'p',
     describe: 'make a pre-release with optional option value to specify a tag id',
-    string: true,
-    global: true
+    string: true
   })
   .option('infile', {
     alias: 'i',
     describe: 'Read the CHANGELOG from this file',
-    default: defaults.infile,
-    global: true
+    default: defaults.infile
   })
   .option('message', {
     alias: 'm',
     describe: 'Commit message, replaces %s with new version',
     type: 'string',
-    default: defaults.message,
-    global: true
+    default: defaults.message
   })
   .option('first-release', {
     alias: 'f',
     describe: 'Is this the first release?',
     type: 'boolean',
-    default: defaults.firstRelease,
-    global: true
+    default: defaults.firstRelease
   })
   .option('sign', {
     alias: 's',
     describe: 'Should the git commit and tag be signed?',
     type: 'boolean',
-    default: defaults.sign,
-    global: true
+    default: defaults.sign
   })
   .option('no-verify', {
     alias: 'n',
     describe: 'Bypass pre-commit or commit-msg git hooks during the commit phase',
     type: 'boolean',
-    default: defaults.noVerify,
-    global: true
+    default: defaults.noVerify
   })
   .option('commit-all', {
     alias: 'a',
     describe: 'Commit all staged changes, not just files affected by standard-version',
     type: 'boolean',
-    default: defaults.commitAll,
-    global: true
+    default: defaults.commitAll
   })
   .option('silent', {
     describe: 'Don\'t print logs and errors',
     type: 'boolean',
-    default: defaults.silent,
-    global: true
+    default: defaults.silent
   })
   .option('tag-prefix', {
     alias: 't',
     describe: 'Set a custom prefix for the git tag to be created',
     type: 'string',
-    default: defaults.tagPrefix,
-    global: true
+    default: defaults.tagPrefix
   })
   .option('scripts', {
     describe: 'Scripts to execute for lifecycle events (prebump, precommit, etc.,)',
-    default: {}
+    default: defaults.scripts
+  })
+  .option('dry-run', {
+    type: 'boolean',
+    default: defaults.dryRun
   })
   .check((argv) => {
     if (typeof argv.scripts !== 'object' || Array.isArray(argv.scripts)) {
-      throw Error('hooks must be an object')
+      throw Error('scripts must be an object')
     } else {
       return true
     }

--- a/command.js
+++ b/command.js
@@ -65,7 +65,8 @@ module.exports = require('yargs')
   })
   .option('dry-run', {
     type: 'boolean',
-    default: defaults.dryRun
+    default: defaults.dryRun,
+    describe: 'See the commands that running standard-version would run'
   })
   .check((argv) => {
     if (typeof argv.scripts !== 'object' || Array.isArray(argv.scripts)) {

--- a/defaults.json
+++ b/defaults.json
@@ -6,5 +6,7 @@
   "noVerify": false,
   "commitAll": false,
   "silent": false,
-  "tagPrefix": "v"
+  "tagPrefix": "v",
+  "scripts": {},
+  "dryRun": false
 }

--- a/lib/checkpoint.js
+++ b/lib/checkpoint.js
@@ -3,8 +3,9 @@ const figures = require('figures')
 const util = require('util')
 
 module.exports = function (argv, msg, args, figure) {
+  const defaultFigure = args.dryRun ? chalk.yellow(figures.tick) : chalk.green(figures.tick)
   if (!argv.silent) {
-    console.info((figure || chalk.green(figures.tick)) + ' ' + util.format.apply(util, [msg].concat(args.map(function (arg) {
+    console.info((figure || defaultFigure) + ' ' + util.format.apply(util, [msg].concat(args.map(function (arg) {
       return chalk.bold(arg)
     }))))
   }

--- a/lib/checkpoint.js
+++ b/lib/checkpoint.js
@@ -2,10 +2,10 @@ const chalk = require('chalk')
 const figures = require('figures')
 const util = require('util')
 
-module.exports = function (argv, msg, args, figure) {
+module.exports = function (args, msg, vars, figure) {
   const defaultFigure = args.dryRun ? chalk.yellow(figures.tick) : chalk.green(figures.tick)
-  if (!argv.silent) {
-    console.info((figure || defaultFigure) + ' ' + util.format.apply(util, [msg].concat(args.map(function (arg) {
+  if (!args.silent) {
+    console.info((figure || defaultFigure) + ' ' + util.format.apply(util, [msg].concat(vars.map(function (arg) {
       return chalk.bold(arg)
     }))))
   }

--- a/lib/print-error.js
+++ b/lib/print-error.js
@@ -1,7 +1,7 @@
 const chalk = require('chalk')
 
-module.exports = function (argv, msg, opts) {
-  if (!argv.silent) {
+module.exports = function (args, msg, opts) {
+  if (!args.silent) {
     opts = Object.assign({
       level: 'error',
       color: 'red'

--- a/lib/run-exec.js
+++ b/lib/run-exec.js
@@ -1,18 +1,18 @@
 const exec = require('child_process').exec
 const printError = require('./print-error')
 
-module.exports = function (argv, cmd) {
-  if (argv.dryRun) return Promise.resolve()
+module.exports = function (args, cmd) {
+  if (args.dryRun) return Promise.resolve()
   return new Promise((resolve, reject) => {
     // Exec given cmd and handle possible errors
     exec(cmd, function (err, stdout, stderr) {
       // If exec returns content in stderr, but no error, print it as a warning
       // If exec returns an error, print it and exit with return code 1
       if (err) {
-        printError(argv, stderr || err.message)
+        printError(args, stderr || err.message)
         return reject(err)
       } else if (stderr) {
-        printError(argv, stderr, {level: 'warn', color: 'yellow'})
+        printError(args, stderr, {level: 'warn', color: 'yellow'})
       }
       return resolve(stdout)
     })

--- a/lib/run-exec.js
+++ b/lib/run-exec.js
@@ -2,6 +2,7 @@ const exec = require('child_process').exec
 const printError = require('./print-error')
 
 module.exports = function (argv, cmd) {
+  if (argv.dryRun) return Promise.resolve()
   return new Promise((resolve, reject) => {
     // Exec given cmd and handle possible errors
     exec(cmd, function (err, stdout, stderr) {

--- a/lib/run-lifecycle-hook.js
+++ b/lib/run-lifecycle-hook.js
@@ -3,10 +3,10 @@ const checkpoint = require('./checkpoint')
 const figures = require('figures')
 const runExec = require('./run-exec')
 
-module.exports = function (argv, hookName, newVersion, hooks, cb) {
+module.exports = function (args, hookName, newVersion, hooks, cb) {
   if (!hooks[hookName]) return Promise.resolve()
   var command = hooks[hookName] + ' --new-version="' + newVersion + '"'
-  checkpoint(argv, 'Running lifecycle hook "%s"', [hookName])
-  checkpoint(argv, '- hook command: "%s"', [command], chalk.blue(figures.info))
-  return runExec(argv, command)
+  checkpoint(args, 'Running lifecycle hook "%s"', [hookName])
+  checkpoint(args, '- hook command: "%s"', [command], chalk.blue(figures.info))
+  return runExec(args, command)
 }

--- a/lib/run-lifecycle-script.js
+++ b/lib/run-lifecycle-script.js
@@ -3,8 +3,9 @@ const checkpoint = require('./checkpoint')
 const figures = require('figures')
 const runExec = require('./run-exec')
 
-module.exports = function (argv, hookName, newVersion, scripts, cb) {
-  if (!scripts[hookName]) return Promise.resolve()
+module.exports = function (argv, hookName, newVersion, args) {
+  const scripts = args.scripts
+  if (!scripts || !scripts[hookName]) return Promise.resolve()
   var command = scripts[hookName]
   if (newVersion) command += ' --new-version="' + newVersion + '"'
   checkpoint(argv, 'Running lifecycle script "%s"', [hookName])

--- a/lib/run-lifecycle-script.js
+++ b/lib/run-lifecycle-script.js
@@ -3,12 +3,12 @@ const checkpoint = require('./checkpoint')
 const figures = require('figures')
 const runExec = require('./run-exec')
 
-module.exports = function (argv, hookName, newVersion, args) {
+module.exports = function (args, hookName, newVersion) {
   const scripts = args.scripts
   if (!scripts || !scripts[hookName]) return Promise.resolve()
   var command = scripts[hookName]
   if (newVersion) command += ' --new-version="' + newVersion + '"'
-  checkpoint(argv, 'Running lifecycle script "%s"', [hookName])
-  checkpoint(argv, '- execute command: "%s"', [command], chalk.blue(figures.info))
-  return runExec(argv, command)
+  checkpoint(args, 'Running lifecycle script "%s"', [hookName])
+  checkpoint(args, '- execute command: "%s"', [command], chalk.blue(figures.info))
+  return runExec(args, command)
 }

--- a/lib/write-file.js
+++ b/lib/write-file.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 
-module.exports = function (argv, filePath, content) {
-  if (argv.dryRun) return
+module.exports = function (args, filePath, content) {
+  if (args.dryRun) return
   fs.writeFileSync(filePath, content, 'utf8')
 }

--- a/lib/write-file.js
+++ b/lib/write-file.js
@@ -1,0 +1,6 @@
+const fs = require('fs')
+
+module.exports = function (argv, filePath, content) {
+  if (argv.dryRun) return
+  fs.writeFileSync(filePath, content, 'utf8')
+}

--- a/test.js
+++ b/test.js
@@ -675,4 +675,17 @@ describe('standard-version', function () {
         })
     })
   })
+
+  describe('dry-run', function () {
+    it('skips all non-idempotent steps', function (done) {
+      commit('feat: first commit')
+      shell.exec('git tag -a v1.0.0 -m "my awesome first release"')
+      commit('feat: new feature!')
+      execCli('--dry-run').stdout.should.match(/### Features/)
+      shell.exec('git log --oneline -n1').stdout.should.match(/feat: new feature!/)
+      shell.exec('git tag').stdout.should.match(/1\.0\.0/)
+      getPackageVersion().should.equal('1.0.0')
+      return done()
+    })
+  })
 })


### PR DESCRIPTION
running standard-version with the flag --dry-run allows you to see what commands would be run, without committing to git or updating files.

@azachar I've implemented your suggestion for dry-run mode here 👍 