### PR TITLE
fix: Recommend --tag when publishing prerelease npm modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ module.exports = function standardVersion (argv) {
   var newVersion = pkg.version
   var defaults = require('./defaults')
   var args = Object.assign({}, defaults, argv)
+  args[Symbol.for('messages')] = []
 
   return runLifecycleScript(args, 'prebump', null)
     .then((stdout) => {
@@ -50,6 +51,9 @@ module.exports = function standardVersion (argv) {
     })
     .then(() => {
       return tag(newVersion, pkg.private, args)
+    })
+    .then(() => {
+      return args[Symbol.for('messages')]
     })
     .catch((err) => {
       printError(args, err.message)
@@ -240,6 +244,7 @@ function tag (newVersion, pkgPrivate, args) {
     .then(() => {
       var message = 'git push --follow-tags origin master'
       if (pkgPrivate !== true) message += '; npm publish'
+      if (args.prerelease !== undefined) message += ' --tag prerelease'
 
       checkpoint(args, 'Run `%s` to publish', [message], chalk.blue(figures.info))
     })

--- a/lib/checkpoint.js
+++ b/lib/checkpoint.js
@@ -4,6 +4,8 @@ const util = require('util')
 
 module.exports = function (args, msg, vars, figure) {
   const defaultFigure = args.dryRun ? chalk.yellow(figures.tick) : chalk.green(figures.tick)
+  args[Symbol.for('messages')].push(util.format.apply(util, [msg].concat(vars)))
+
   if (!args.silent) {
     console.info((figure || defaultFigure) + ' ' + util.format.apply(util, [msg].concat(vars.map(function (arg) {
       return chalk.bold(arg)

--- a/test.js
+++ b/test.js
@@ -349,7 +349,8 @@ describe('cli', function () {
 
       commit('feat: first commit')
       return execCliAsync('--prerelease')
-        .then(function () {
+        .then(function (messages) {
+          messages[messages.length - 1].should.equal('Run `git push --follow-tags origin master; npm publish --tag prerelease` to publish')
           // it's a feature commit, so it's minor type
           getPackageVersion().should.equal('1.1.0-0')
         })


### PR DESCRIPTION
The --tag argument to npm publish allows you to publish a prerelease without the prerelease assuming
the 'latest' tag and causing users to download the prerelease by default. Instead, we recommend
`--tag prerelease` by default when `--prerelease` is set in the `standard-version` call, so to
install a prerelease version of the module, users will install `module@foo` or specify the exact
version of the prerelease version.

Fixes #183