### PR TITLE
fix: Recommend --tag prerelease for npm publish of prereleases

### DIFF
--- a/lib/lifecycles/tag.js
+++ b/lib/lifecycles/tag.js
@@ -28,6 +28,7 @@ function execTag (newVersion, pkgPrivate, args) {
     .then(() => {
       var message = 'git push --follow-tags origin master'
       if (pkgPrivate !== true) message += '; npm publish'
+      if (args.prerelease !== undefined) message += ' --tag prerelease'
 
       checkpoint(args, 'Run `%s` to publish', [message], chalk.blue(figures.info))
     })

--- a/test.js
+++ b/test.js
@@ -360,6 +360,14 @@ describe('cli', function () {
           getPackageVersion().should.equal('1.1.0-0')
         })
     })
+
+    it('advises use of --tag prerelease for publishing to npm', function () {
+      writePackageJson('1.0.0')
+      fs.writeFileSync('CHANGELOG.md', 'legacy header format<a name="1.0.0">\n', 'utf-8')
+
+      commit('feat: first commit')
+      execCli('--prerelease').stdout.should.include('--tag prerelease')
+    })
   })
 
   describe('manual-release', function () {


### PR DESCRIPTION
The --tag argument to npm publish allows you to publish a prerelease without the prerelease assuming
the 'latest' tag and causing users to download the prerelease by default. Instead, we recommend
`--tag prerelease` by default when `--prerelease` is set in the `standard-version` call, so to
install a prerelease version of the module, users will install `module@foo` or specify the exact
version of the prerelease version.

Fixes #183 

Supersedes #189