### PR TITLE
fix: use the `skip` default value for skip cli arg

### DIFF
--- a/command.js
+++ b/command.js
@@ -65,7 +65,7 @@ module.exports = require('yargs')
   })
   .option('skip', {
     describe: 'Map of steps in the release process that should be skipped',
-    default: defaults.scripts
+    default: defaults.skip
   })
   .option('dry-run', {
     type: 'boolean',


### PR DESCRIPTION
Even though the defaults for both `skip` and `scripts` were empty
objects, the code was referencing the default value for `scripts` in
both places, which could lead to a bug in the future if the default for
either changed at some point in the future.