### PR TITLE
Feature/support multiple new version in format

### DIFF
--- a/lib/format-commit-message.js
+++ b/lib/format-commit-message.js
@@ -1,5 +1,10 @@
 const util = require('util')
 
-module.exports = function (msg, newVersion) {
-  return String(msg).indexOf('%s') !== -1 ? util.format(msg, newVersion) : msg
+module.exports = function (rawMsg, newVersion) {
+  const message = String(rawMsg)
+  const matchCount = (message.match(/%s/g) || []).length
+  const args = Array(1 + matchCount)
+  args[0] = message
+  args.fill(newVersion, 1, args.length)
+  return util.format.apply(util, args)
 }

--- a/test.js
+++ b/test.js
@@ -9,6 +9,7 @@ var stream = require('stream')
 var mockGit = require('mock-git')
 var mockery = require('mockery')
 var semver = require('semver')
+var formatCommitMessage = require('./lib/format-commit-message')
 var cli = require('./command')
 var standardVersion = require('./index')
 
@@ -100,6 +101,18 @@ function finishTemp () {
 function getPackageVersion () {
   return JSON.parse(fs.readFileSync('package.json', 'utf-8')).version
 }
+
+describe('format-commit-message', function () {
+  it('works for no %s', function () {
+    formatCommitMessage('chore(release): 1.0.0', '1.0.0').should.equal('chore(release): 1.0.0')
+  })
+  it('works for one %s', function () {
+    formatCommitMessage('chore(release): %s', '1.0.0').should.equal('chore(release): 1.0.0')
+  })
+  it('works for two %s', function () {
+    formatCommitMessage('chore(release): %s \n\n* CHANGELOG: https://github.com/conventional-changelog/standard-version/blob/v%s/CHANGELOG.md', '1.0.0').should.equal('chore(release): 1.0.0 \n\n* CHANGELOG: https://github.com/conventional-changelog/standard-version/blob/v1.0.0/CHANGELOG.md')
+  })
+})
 
 describe('cli', function () {
   beforeEach(initInTempFolder)


### PR DESCRIPTION
# Description

Add support for commit message like this:

## In npm scripts

One can use `\n` here:

```json
  "scripts": {
    "release": "standard-version -m 'chore(release): %s \n\n* CHANGELOG: https://github.com/conventional-changelog/standard-version/blob/v%s/CHANGELOG.md'"
  },
```

## In shell directly

But has to enter `\` manually in shell

```sh
> standard-version -m 'chore(release): %s \
quote> \
quote> \
quote> * CHANGELOG: https://github.com/conventional-changelog/standard-version/blob/v%s/CHANGELOG.md'
```

## which generates this in git commit message:

```txt
chore(release): 1.0.0

* CHANGELOG: https://github.com/conventional-changelog/standard-version/blob/v1.0.0/CHANGELOG.md
```