### PR TITLE
feat: add prerelease lifecycle script hook (closes #217)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ If you have your GPG key set up, add the `--sign` or `-s` flag to your `standard
 own supplementary commands during the release. The following
 hooks are available and execute in the order documented:
 
+* `prerelease`: executed before anything happens. If the `prerelease` script returns a
+  non-zero exit code, versioning will be aborted, but it has no other effect on the
+  process.
 * `prebump`/`postbump`: executed before and after the version is bumped. If the `prebump`
   script returns a version #, it will be used rather than
   the version calculated by `standard-version`.

--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -20,7 +20,8 @@ function Bump (args, pkg) {
 
   if (args.skip.bump) return Promise.resolve()
   var newVersion = pkg.version
-  return runLifecycleScript(args, 'prebump')
+  return runLifecycleScript(args, 'prerelease')
+    .then(runLifecycleScript.bind(this, args, 'prebump'))
     .then((stdout) => {
       if (stdout && stdout.trim().length) args.releaseAs = stdout.trim()
       return bumpVersion(args.releaseAs)

--- a/test.js
+++ b/test.js
@@ -252,6 +252,42 @@ describe('cli', function () {
   })
 
   describe('lifecycle scripts', () => {
+    describe('prerelease hook', function () {
+      it('should run the prerelease hook when provided', function () {
+        writePackageJson('1.0.0', {
+          'standard-version': {
+            'scripts': {
+              'prerelease': 'node scripts/prerelease'
+            }
+          }
+        })
+        writeHook('prerelease')
+        fs.writeFileSync('CHANGELOG.md', 'legacy header format<a name="1.0.0">\n', 'utf-8')
+
+        commit('feat: first commit')
+        var result = execCli('--patch')
+        result.code.should.equal(0)
+        result.stderr.should.match(/prerelease ran/)
+      })
+
+      it('should abort if the hook returns a non-zero exit code', function () {
+        writePackageJson('1.0.0', {
+          'standard-version': {
+            'scripts': {
+              'prerelease': 'node scripts/prerelease && exit 1'
+            }
+          }
+        })
+        writeHook('prerelease')
+        fs.writeFileSync('CHANGELOG.md', 'legacy header format<a name="1.0.0">\n', 'utf-8')
+
+        commit('feat: first commit')
+        var result = execCli('--patch')
+        result.code.should.equal(1)
+        result.stderr.should.match(/prerelease ran/)
+      })
+    })
+
     describe('prebump hook', function () {
       it('should allow prebump hook to return an alternate version #', function () {
         writePackageJson('1.0.0', {


### PR DESCRIPTION
It took me a while to get around to it, but here's an implementation of a pre-everything script hook that won't affect behavior further into the process.