### PR TITLE
feat: manifest.json support

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const tag = require('./lib/lifecycles/tag')
 module.exports = function standardVersion (argv) {
   var pkg
   bump.pkgFiles.forEach((filename) => {
+    if (pkg) return
     var pkgPath = path.resolve(process.cwd(), filename)
     try {
       pkg = require(pkgPath)

--- a/index.js
+++ b/index.js
@@ -7,8 +7,16 @@ const commit = require('./lib/lifecycles/commit')
 const tag = require('./lib/lifecycles/tag')
 
 module.exports = function standardVersion (argv) {
-  var pkgPath = path.resolve(process.cwd(), './package.json')
-  var pkg = require(pkgPath)
+  var pkg
+  bump.pkgFiles.forEach((filename) => {
+    var pkgPath = path.resolve(process.cwd(), filename)
+    try {
+      pkg = require(pkgPath)
+    } catch (err) {}
+  })
+  if (!pkg) {
+    throw new Error('no package file found')
+  }
   var newVersion = pkg.version
   var defaults = require('./defaults')
   var args = Object.assign({}, defaults, argv)

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function standardVersion (argv) {
     } catch (err) {}
   })
   if (!pkg) {
-    throw new Error('no package file found')
+    return Promise.reject(new Error('no package file found'))
   }
   var newVersion = pkg.version
   var defaults = require('./defaults')

--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -46,6 +46,17 @@ Bump.getUpdatedConfigs = function () {
   return configsToUpdate
 }
 
+Bump.pkgFiles = [
+  'package.json',
+  'bower.json',
+  'manifest.json'
+]
+
+Bump.lockFiles = [
+  'package-lock.json',
+  'npm-shrinkwrap.json'
+]
+
 function getReleaseType (prerelease, expectedReleaseType, currentVersion) {
   if (isString(prerelease)) {
     if (isInPrerelease(currentVersion)) {
@@ -138,10 +149,9 @@ function bumpVersion (releaseAs, callback) {
  */
 function updateConfigs (args, newVersion) {
   const dotgit = DotGitignore()
-  configsToUpdate[path.resolve(process.cwd(), './package.json')] = false
-  configsToUpdate[path.resolve(process.cwd(), './package-lock.json')] = false
-  configsToUpdate[path.resolve(process.cwd(), './npm-shrinkwrap.json')] = false
-  configsToUpdate[path.resolve(process.cwd(), './bower.json')] = false
+  Bump.pkgFiles.concat(Bump.lockFiles).forEach((filename) => {
+    configsToUpdate[path.resolve(process.cwd(), filename)] = false
+  })
   Object.keys(configsToUpdate).forEach(function (configPath) {
     try {
       if (dotgit.ignore(configPath)) return

--- a/test.js
+++ b/test.js
@@ -699,6 +699,16 @@ describe('standard-version', function () {
       })
   })
 
+  describe('without a package file to bump', function () {
+    it('should exit with error', function () {
+      shell.rm('package.json')
+      return require('./index')({silent: true})
+        .catch((err) => {
+          err.message.should.equal('no package file found')
+        })
+    })
+  })
+
   describe('bower.json support', function () {
     beforeEach(function () {
       writeBowerJson('1.0.0')
@@ -765,16 +775,6 @@ describe('standard-version', function () {
         .then(() => {
           JSON.parse(fs.readFileSync('package-lock.json', 'utf-8')).version.should.equal('1.1.0')
           getPackageVersion().should.equal('1.1.0')
-        })
-    })
-  })
-
-  describe('without a package file to bump', function () {
-    it('should exit with error', function () {
-      shell.rm('package.json')
-      return require('./index')({silent: true})
-        .catch((err) => {
-          err.message.should.equal('no package file found')
         })
     })
   })

--- a/test.js
+++ b/test.js
@@ -769,6 +769,17 @@ describe('standard-version', function () {
     })
   })
 
+  describe('without a package file to bump', function () {
+    it('should exit with error', function () {
+      shell.rm('package.json')
+      return require('./index')({silent: true})
+        .catch((err) => {
+          err.message.should.equal('no package file found')
+        })
+
+    })
+  })
+
   describe('dry-run', function () {
     it('skips all non-idempotent steps', function (done) {
       commit('feat: first commit')

--- a/test.js
+++ b/test.js
@@ -54,6 +54,12 @@ function writeBowerJson (version, option) {
   fs.writeFileSync('bower.json', JSON.stringify(bower), 'utf-8')
 }
 
+function writeManifestJson (version, option) {
+  option = option || {}
+  var manifest = Object.assign(option, {version: version})
+  fs.writeFileSync('manifest.json', JSON.stringify(manifest), 'utf-8')
+}
+
 function writeNpmShrinkwrapJson (version, option) {
   option = option || {}
   var shrinkwrap = Object.assign(option, { version: version })
@@ -705,6 +711,23 @@ describe('standard-version', function () {
       return require('./index')({silent: true})
         .then(() => {
           JSON.parse(fs.readFileSync('bower.json', 'utf-8')).version.should.equal('1.1.0')
+          getPackageVersion().should.equal('1.1.0')
+        })
+    })
+  })
+
+  describe.only('manifest.json support', function () {
+    beforeEach(function () {
+      writeManifestJson('1.0.0')
+    })
+
+    it('bumps version # in manifest.json', function () {
+      commit('feat: first commit')
+      shell.exec('git tag -a v1.0.0 -m "my awesome first release"')
+      commit('feat: new feature!')
+      return require('./index')({silent: true})
+        .then(() => {
+          JSON.parse(fs.readFileSync('manifest.json', 'utf-8')).version.should.equal('1.1.0')
           getPackageVersion().should.equal('1.1.0')
         })
     })

--- a/test.js
+++ b/test.js
@@ -716,7 +716,7 @@ describe('standard-version', function () {
     })
   })
 
-  describe.only('manifest.json support', function () {
+  describe('manifest.json support', function () {
     beforeEach(function () {
       writeManifestJson('1.0.0')
     })

--- a/test.js
+++ b/test.js
@@ -776,7 +776,6 @@ describe('standard-version', function () {
         .catch((err) => {
           err.message.should.equal('no package file found')
         })
-
     })
   })
 


### PR DESCRIPTION
Hi there,

I've added support for updating a `manifest.json` file, which is used in Google Chrome extensions. 
There's potential in standard-release to be used for software packages that are not node.js related or don't use npm. And I think this is a good start towards that.

Thank you for this tool btw, it's helped me a lot!