### PR TITLE
Show full tag name in checkpoint

### DIFF
--- a/lib/lifecycles/tag.js
+++ b/lib/lifecycles/tag.js
@@ -23,7 +23,7 @@ function execTag (newVersion, pkgPrivate, args) {
   } else {
     tagOption = '-a '
   }
-  checkpoint(args, 'tagging release %s', [newVersion])
+  checkpoint(args, 'tagging release %s%s', [args.tagPrefix, newVersion])
   return runExec(args, 'git tag ' + tagOption + args.tagPrefix + newVersion + ' -m "' + formatCommitMessage(args.message, newVersion) + '"')
     .then(() => {
       var message = 'git push --follow-tags origin master'


### PR DESCRIPTION
Tried this package out for the first time and wanted to undo what it had done.
When I tried to remove the tag, I assumed the output "tagging release 0.0.1" was the exact name of the tag, but it was `v0.0.1`.

This changes it so the output is representing the actual name of the tag, and not just the version.