### PR TITLE
Use tagPrefix in conventional-changelog

### DIFF
--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -30,7 +30,8 @@ function outputChangelog (args, newVersion) {
     var context
     if (args.dryRun) context = {version: newVersion}
     var changelogStream = conventionalChangelog({
-      preset: 'angular'
+      preset: 'angular',
+      tagPrefix: args.tagPrefix
     }, context, {merges: null})
       .on('error', function (err) {
         return reject(err)


### PR DESCRIPTION
Use tagPrefix arg if passed also in conventional-changelog
If we won't to do it, the last commit won't find if we use custom tagPrefix