### PR TITLE
fix semver dep version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "dotgitignore": "^1.0.3",
     "figures": "^2.0.0",
     "fs-access": "^1.0.0",
-    "semver": "^5.1.0",
+    "semver": "^5.2.0",
     "yargs": "^12.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
fixes #175

exports.prerelease was added in 5.2.0, see:
https://github.com/npm/node-semver/commit/3cc5a94c15f5874b7c12f7cc5cf03f8f07b476ba