### PR TITLE
Releasing named prerelease advises to push same tag-name

### DIFF
--- a/lib/lifecycles/tag.js
+++ b/lib/lifecycles/tag.js
@@ -28,7 +28,13 @@ function execTag (newVersion, pkgPrivate, args) {
     .then(() => {
       var message = 'git push --follow-tags origin master'
       if (pkgPrivate !== true) message += ' && npm publish'
-      if (args.prerelease !== undefined) message += ' --tag prerelease'
+      if (args.prerelease !== undefined) {
+        if (args.prerelease === '') {
+          message += ' --tag prerelease'
+        } else {
+          message += ' --tag ' + args.prerelease
+        }
+      }
 
       checkpoint(args, 'Run `%s` to publish', [message], chalk.blue(figures.info))
     })

--- a/test.js
+++ b/test.js
@@ -423,6 +423,14 @@ describe('cli', function () {
       commit('feat: first commit')
       execCli('--prerelease').stdout.should.include('--tag prerelease')
     })
+
+    it('advises use of --tag alpha for publishing to npm when tagging alpha', function () {
+      writePackageJson('1.0.0')
+      fs.writeFileSync('CHANGELOG.md', 'legacy header format<a name="1.0.0">\n', 'utf-8')
+
+      commit('feat: first commit')
+      execCli('--prerelease alpha').stdout.should.include('--tag alpha')
+    })
   })
 
   describe('manual-release', function () {


### PR DESCRIPTION
Hi,
This change adds the correct advise to push the same named tag to npm, too.
So that `npm run release -- --prerelease alpha` advises to push to the alpha tag on npm