### PR TITLE
feat: allows configuration of standard-version and submodules using package.json or a provided --config file

### DIFF
--- a/command.js
+++ b/command.js
@@ -93,7 +93,7 @@ module.exports = require('yargs')
     function (configPath) {
       const parsed = {}
       if (!fs.existsSync(configPath)) {
-        return parsed
+        throw Error('unable to locate provided configuration file')
       }
       const config = require(configPath)
       if (typeof config === 'function') {

--- a/index.js
+++ b/index.js
@@ -1,11 +1,3 @@
-<<<<<<< HEAD
-=======
-const fs = require('fs')
-const latestSemverTag = require('./lib/latest-semver-tag')
-const path = require('path')
-const printError = require('./lib/print-error')
-
->>>>>>> fix: ensure configuration fallback when configration file or package.json is not present
 const bump = require('./lib/lifecycles/bump')
 const changelog = require('./lib/lifecycles/changelog')
 const commit = require('./lib/lifecycles/commit')

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = function standardVersion (argv) {
   })
   let newVersion
   let defaults = require('./defaults')
-  const packageConfiguration = getConfigurationFromArguments(argv)
+  const packageConfiguration = Object.assign({}, getConfigurationFromArguments(argv))
   // the `modules` key is reserved for submodule configurations.
   const moduleConfigurations = packageConfiguration.modules || {}
   // module specific configurations are *not* passed as part of `standard-version`s arguments.

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = function standardVersion (argv) {
       return bump(
         args,
         newVersion,
-        moduleConfigurations['conventional-recommended-bump']
+        moduleConfigurations
       )
     })
     .then((_newVersion) => {
@@ -52,7 +52,7 @@ module.exports = function standardVersion (argv) {
       return changelog(
         args,
         newVersion,
-        moduleConfigurations['conventional-changelog']
+        moduleConfigurations
       )
     })
     .then(() => {

--- a/index.js
+++ b/index.js
@@ -7,26 +7,6 @@ const path = require('path')
 const printError = require('./lib/print-error')
 const tag = require('./lib/lifecycles/tag')
 
-// allows configuration of `standard-version` and submodules via `standard-version`
-// key in `package.json` or a provided `--config` file.
-function getConfigurationFromArguments (argv) {
-  const hasConfigArg = Boolean(argv.config)
-  const configurationPath = path.resolve(process.cwd(), hasConfigArg ? argv.config : 'package.json')
-  if (!fs.existsSync(configurationPath)) {
-    return {}
-  }
-  const config = require(configurationPath)
-  if (typeof config === 'function') {
-    // if the export of the configuraiton is a function, we expect the
-    // result to be our configuration object.
-    return config()
-  }
-  if (typeof config === 'object') {
-    return !hasConfigArg || config.hasOwnProperty('standard-version') ? (config['standard-version'] || {}) : config
-  }
-  return {}
-}
-
 module.exports = function standardVersion (argv) {
   let pkg
   bump.pkgFiles.forEach((filename) => {
@@ -39,7 +19,7 @@ module.exports = function standardVersion (argv) {
   })
   let newVersion
   let defaults = require('./defaults')
-  const packageConfiguration = Object.assign({}, getConfigurationFromArguments(argv))
+  const packageConfiguration = Object.assign({}, argv.configuration)
   // the `modules` key is reserved for submodule configurations.
   const moduleConfigurations = packageConfiguration.modules || {}
   // module specific configurations are *not* passed as part of `standard-version`s arguments.

--- a/index.js
+++ b/index.js
@@ -77,7 +77,11 @@ module.exports = function standardVersion (argv) {
       // if bump runs, it calculaes the new version that we
       // should release at.
       if (_newVersion) newVersion = _newVersion
-      return changelog(args, newVersion)
+      return changelog(
+        args,
+        newVersion,
+        moduleConfigurations['conventional-changelog']
+      )
     })
     .then(() => {
       return commit(args, newVersion)

--- a/index.js
+++ b/index.js
@@ -1,3 +1,11 @@
+<<<<<<< HEAD
+=======
+const fs = require('fs')
+const latestSemverTag = require('./lib/latest-semver-tag')
+const path = require('path')
+const printError = require('./lib/print-error')
+
+>>>>>>> fix: ensure configuration fallback when configration file or package.json is not present
 const bump = require('./lib/lifecycles/bump')
 const changelog = require('./lib/lifecycles/changelog')
 const commit = require('./lib/lifecycles/commit')
@@ -12,6 +20,9 @@ const tag = require('./lib/lifecycles/tag')
 function getConfigurationFromArguments (argv) {
   const hasConfigArg = Boolean(argv.config)
   const configurationPath = path.resolve(process.cwd(), hasConfigArg ? argv.config : 'package.json')
+  if (!fs.existsSync(configurationPath)) {
+    return {}
+  }
   const config = require(configurationPath)
   if (typeof config === 'function') {
     // if the export of the configuraiton is a function, we expect the

--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -14,15 +14,16 @@ const semver = require('semver')
 const stringifyPackage = require('stringify-package')
 const writeFile = require('../write-file')
 
-var configsToUpdate = {}
+let configsToUpdate = {}
+let moduleConfiguration = {}
 
-function Bump (args, version) {
+function Bump (args, version, configuration) {
   // reset the cache of updated config files each
   // time we perform the version bump step.
   configsToUpdate = {}
-
+  moduleConfiguration = configuration || {}
   if (args.skip.bump) return Promise.resolve()
-  var newVersion = version
+  let newVersion = version
   return runLifecycleScript(args, 'prerelease')
     .then(runLifecycleScript.bind(this, args, 'prebump'))
     .then((stdout) => {
@@ -31,7 +32,7 @@ function Bump (args, version) {
     })
     .then((release) => {
       if (!args.firstRelease) {
-        var releaseType = getReleaseType(args.prerelease, release.releaseType, version)
+        let releaseType = getReleaseType(args.prerelease, release.releaseType, version)
         newVersion = semver.valid(releaseType) || semver.inc(version, releaseType, args.prerelease)
         updateConfigs(args, newVersion)
       } else {
@@ -135,11 +136,12 @@ function bumpVersion (releaseAs, args) {
         releaseType: releaseAs
       })
     } else {
-      conventionalRecommendedBump({
+      conventionalRecommendedBump(Object.assign({
         debug: args.verbose && console.info.bind(console, 'conventional-recommended-bump'),
         preset: args.preset || 'angular',
         path: args.path
-      }, function (err, release) {
+      }, moduleConfiguration),
+      function (err, release) {
         if (err) return reject(err)
         else return resolve(release)
       })

--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -21,7 +21,7 @@ function Bump (args, version, configuration) {
   // reset the cache of updated config files each
   // time we perform the version bump step.
   configsToUpdate = {}
-  moduleConfiguration = configuration || {}
+  moduleConfiguration = configuration['conventional-recommended-bump'] || {}
   if (args.skip.bump) return Promise.resolve()
   let newVersion = version
   return runLifecycleScript(args, 'prerelease')

--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -6,18 +6,18 @@ const fs = require('fs')
 const runLifecycleScript = require('../run-lifecycle-script')
 const writeFile = require('../write-file')
 
-module.exports = function (args, newVersion, moduleConfiguration) {
+module.exports = function (args, newVersion, moduleConfigurations) {
   if (args.skip.changelog) return Promise.resolve()
   return runLifecycleScript(args, 'prechangelog')
     .then(() => {
-      return outputChangelog(args, newVersion, moduleConfiguration)
+      return outputChangelog(args, newVersion, moduleConfigurations)
     })
     .then(() => {
       return runLifecycleScript(args, 'postchangelog')
     })
 }
 
-function outputChangelog (args, newVersion, moduleConfiguration) {
+function outputChangelog (args, newVersion, moduleConfigurations) {
   return new Promise((resolve, reject) => {
     createIfMissing(args)
     var header = '# Change Log\n\nAll notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.\n'
@@ -28,19 +28,20 @@ function outputChangelog (args, newVersion, moduleConfiguration) {
       oldContent = oldContent.substring(oldContent.search(changelogSectionRegExp))
     }
     var content = ''
-    var context
-    if (args.dryRun) context = { version: newVersion }
+    var context = {}
+    if (args.dryRun) context.version = newVersion
+    Object.assign(context, moduleConfigurations['conventional-changelog-core'])
 
     var config = Object.assign({}, {
       debug: args.verbose && console.info.bind(console, 'conventional-changelog'),
       preset: args.preset || 'angular',
-      tagPrefix: args.tagPrefix,
-      ...moduleConfiguration
+      tagPrefix: args.tagPrefix
     })
+    Object.assign(config, moduleConfigurations['conventional-changelog'])
 
     var changelogStream = conventionalChangelog(
       config,
-      { ...context, ...moduleConfiguration },
+      context,
       { merges: null, path: args.path }
     ).on('error', function (err) {
       return reject(err)

--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -39,10 +39,10 @@ function outputChangelog (args, newVersion, moduleConfiguration) {
 
     var changelogStream = conventionalChangelog(
       config,
-      context, 
+      context,
       { merges: null, path: args.path }
     ).on('error', function (err) {
-        return reject(err)
+      return reject(err)
     })
 
     changelogStream.on('data', function (buffer) {

--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -34,12 +34,13 @@ function outputChangelog (args, newVersion, moduleConfiguration) {
     var config = Object.assign({}, {
       debug: args.verbose && console.info.bind(console, 'conventional-changelog'),
       preset: args.preset || 'angular',
-      tagPrefix: args.tagPrefix
-    }, moduleConfiguration)
+      tagPrefix: args.tagPrefix,
+      ...moduleConfiguration
+    })
 
     var changelogStream = conventionalChangelog(
       config,
-      context,
+      { ...context, ...moduleConfiguration },
       { merges: null, path: args.path }
     ).on('error', function (err) {
       return reject(err)

--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -6,18 +6,18 @@ const fs = require('fs')
 const runLifecycleScript = require('../run-lifecycle-script')
 const writeFile = require('../write-file')
 
-module.exports = function (args, newVersion) {
+module.exports = function (args, newVersion, moduleConfiguration) {
   if (args.skip.changelog) return Promise.resolve()
   return runLifecycleScript(args, 'prechangelog')
     .then(() => {
-      return outputChangelog(args, newVersion)
+      return outputChangelog(args, newVersion, moduleConfiguration)
     })
     .then(() => {
       return runLifecycleScript(args, 'postchangelog')
     })
 }
 
-function outputChangelog (args, newVersion) {
+function outputChangelog (args, newVersion, moduleConfiguration) {
   return new Promise((resolve, reject) => {
     createIfMissing(args)
     var header = '# Change Log\n\nAll notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.\n'
@@ -30,14 +30,20 @@ function outputChangelog (args, newVersion) {
     var content = ''
     var context
     if (args.dryRun) context = { version: newVersion }
-    var changelogStream = conventionalChangelog({
+
+    var config = Object.assign({}, {
       debug: args.verbose && console.info.bind(console, 'conventional-changelog'),
       preset: args.preset || 'angular',
       tagPrefix: args.tagPrefix
-    }, context, { merges: null, path: args.path })
-      .on('error', function (err) {
+    }, moduleConfiguration)
+
+    var changelogStream = conventionalChangelog(
+      config,
+      context, 
+      { merges: null, path: args.path }
+    ).on('error', function (err) {
         return reject(err)
-      })
+    })
 
     changelogStream.on('data', function (buffer) {
       content += buffer.toString()

--- a/test.js
+++ b/test.js
@@ -210,7 +210,7 @@ describe('cli', function () {
        * `conventional-changelog/conventional-changelog-core`, _or_ a configuration
        * value is missing.
        */
-      // content.should.contain('other-git-service.com')
+      content.should.contain('other-git-service.com')
     })
   })
 

--- a/test.js
+++ b/test.js
@@ -189,6 +189,9 @@ describe('cli', function () {
         execCli('--config functional-config.js').code.should.equal(0)
         assertPresetOverrideCHANGELOG()
       })
+      it('providing and invalid configuration file will result in an error', function () {
+        execCli('--config fake-file.js').code.should.above(0)
+      })
       it('allows modules["conventional-changelog"].preset and modules["conventional-changelog-core"] options', function () {
         writePackageJson('2.0.0', {
           'standard-version': {

--- a/test.js
+++ b/test.js
@@ -190,6 +190,28 @@ describe('cli', function () {
         assertPresetOverrideCHANGELOG()
       })
     })
+    it('allows configuration of repository options', function () {
+      writePackageJson('2.0.0', {
+        'standard-version': {
+          modules: {
+            'conventional-changelog': {
+              repoUrl: 'https://other-git-service.com/repoUrl',
+              host: 'https://other-git-service.com',
+              repository: 'git+https://other-git-service.com/repository.git'
+            }
+          }
+        }
+      })
+      commit('feat: angular style commit with issue reference\n\n#278')
+      execCli().code.should.equal(0)
+      var content = fs.readFileSync('CHANGELOG.md', 'utf-8')
+      /**
+       * @todo this test fails. it seems like it could actually be an issue with
+       * `conventional-changelog/conventional-changelog-core`, _or_ a configuration
+       * value is missing.
+       */
+      // content.should.contain('other-git-service.com')
+    })
   })
 
   describe('CHANGELOG.md does not exist', function () {

--- a/test.js
+++ b/test.js
@@ -195,8 +195,8 @@ describe('cli', function () {
         'standard-version': {
           modules: {
             'conventional-changelog': {
+              host: 'gitlab',
               repoUrl: 'https://other-git-service.com/repoUrl',
-              host: 'https://other-git-service.com',
               repository: 'git+https://other-git-service.com/repository.git'
             }
           }


### PR DESCRIPTION
#### feat: allows configuration of standard-version and submodules using package.json or a provided --config fileackage.json or a provided --config file

see conventional-changelog/standard-version#169, conventional-changelog/standard-version#154

--

I threw together this POC based on [comment](https://github.com/conventional-changelog/standard-version/issues/154#issuecomment-347768419) I came across while looking into the next steps for basic customization in the `conventional-changelog` ecosystem.

Our team is currently using `standard-version` and we have been adhering to the `angular` preset for some time... we'd like to be able to swap this preset for our own, but continue to use `standard-version`.

I started this PR _only_ supporting the `standard-version` key in `package.json`, but quickly saw the need for additional allowed types (`whatBump` in `conventional-recommended-bump`). This resulted in the addition of the `--config` flag.

Again, this is just a POC and I've only updated `bump` – would love to hear the current stance on this type of update!

Examples: 

**`package.json` : Basic `standard-version` Configuration**
```js
// package.json
  "standard-version": {
    "infile": "01-CHANGELOG.md"
  }
```

```bash
$ node bin/cli.js --dry-run 
✔ bumping version in package.json from 5.0.0 to 6.0.0
✔ created 01-CHANGELOG.md
✔ outputting changes to 01-CHANGELOG.md

---
...
```

**`package.json` : `standard-version` "Module" Configuration**
```js
// package.json
  "standard-version": {
    "modules": {
      "conventional-recommended-bump": {
        "preset": "foobar"
      }
    }
  }
```

```bash
$ node bin/cli.js --dry-run 
Unable to load the "foobar" preset package. Please make sure it's installed.
```

**`--config`** : Custom Configuration*
```js
// test.config.js


module.exports = {
  infile: `CHANGELOG-${new Date().valueOf()}.md`,
  'modules': {
    'conventional-recommended-bump': {
      whatBump: function (commit) {
        console.log('hello, world:', commit[0].subject);
      }
    }
  }
}

```

```bash
$ node bin/cli.js --dry-run --config=test.config.js 
hello, world: allows configuration of standard-version and submodules using package.json or a provided --config file
✔ bumping version in package.json from 5.0.0 to null
✔ created CHANGELOG-1542829185913.md
✔ outputting changes to CHANGELOG-1542829185913.md

---
...
```



