### PR TITLE
feat: cli application accept path option

### DIFF
--- a/command.js
+++ b/command.js
@@ -81,6 +81,11 @@ module.exports = require('yargs')
     type: 'string',
     describe: 'Only populate commits made under this path'
   })
+  .option('preset', {
+    type: 'string',
+    default: defaults.preset,
+    describe: 'Commit message guideline preset (default: angular)'
+  })
   .check((argv) => {
     if (typeof argv.scripts !== 'object' || Array.isArray(argv.scripts)) {
       throw Error('scripts must be an object')

--- a/command.js
+++ b/command.js
@@ -79,7 +79,7 @@ module.exports = require('yargs')
   })
   .option('path', {
     type: 'string',
-    describe: 'Only populate commits made under this path',
+    describe: 'Only populate commits made under this path'
   })
   .check((argv) => {
     if (typeof argv.scripts !== 'object' || Array.isArray(argv.scripts)) {

--- a/command.js
+++ b/command.js
@@ -77,6 +77,10 @@ module.exports = require('yargs')
     default: defaults.gitTagFallback,
     describe: `fallback to git tags for version, if no meta-information file is found (e.g., package.json)`
   })
+  .option('path', {
+    type: 'string',
+    describe: 'Only populate commits made under this path',
+  })
   .check((argv) => {
     if (typeof argv.scripts !== 'object' || Array.isArray(argv.scripts)) {
       throw Error('scripts must be an object')

--- a/defaults.json
+++ b/defaults.json
@@ -10,5 +10,6 @@
   "scripts": {},
   "skip": {},
   "dryRun": false,
-  "gitTagFallback": true
+  "gitTagFallback": true,
+  "preset": "angular"
 }

--- a/index.js
+++ b/index.js
@@ -34,11 +34,14 @@ module.exports = function standardVersion (argv) {
       newVersion = version
     })
     .then(() => {
+      console.info("standard-version", args);
       return bump(args, newVersion)
     })
     .then((_newVersion) => {
       // if bump runs, it calculaes the new version that we
       // should release at.
+      console.info("standard-version newVersion:", _newVersion);
+      console.info("standard-version args before changelog():", args);
       if (_newVersion) newVersion = _newVersion
       return changelog(args, newVersion)
     })

--- a/index.js
+++ b/index.js
@@ -34,14 +34,11 @@ module.exports = function standardVersion (argv) {
       newVersion = version
     })
     .then(() => {
-      console.info("standard-version", args);
       return bump(args, newVersion)
     })
     .then((_newVersion) => {
       // if bump runs, it calculaes the new version that we
       // should release at.
-      console.info("standard-version newVersion:", _newVersion);
-      console.info("standard-version args before changelog():", args);
       if (_newVersion) newVersion = _newVersion
       return changelog(args, newVersion)
     })

--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -134,7 +134,7 @@ function bumpVersion (releaseAs, args) {
     } else {
       conventionalRecommendedBump({
         debug: args.verbose && console.info.bind(console, 'conventional-recommended-bump'),
-        preset: 'angular',
+        preset: args.preset || 'angular',
         path: args.path
       }, function (err, release) {
         if (err) return reject(err)

--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -24,7 +24,7 @@ function Bump (args, version) {
     .then(runLifecycleScript.bind(this, args, 'prebump'))
     .then((stdout) => {
       if (stdout && stdout.trim().length) args.releaseAs = stdout.trim()
-      return bumpVersion(args.releaseAs)
+      return bumpVersion(args.releaseAs, args)
     })
     .then((release) => {
       if (!args.firstRelease) {
@@ -125,7 +125,7 @@ function getTypePriority (type) {
   return TypeList.indexOf(type)
 }
 
-function bumpVersion (releaseAs, callback) {
+function bumpVersion (releaseAs, args) {
   return new Promise((resolve, reject) => {
     if (releaseAs) {
       return resolve({
@@ -133,8 +133,11 @@ function bumpVersion (releaseAs, callback) {
       })
     } else {
       conventionalRecommendedBump({
-        preset: 'angular'
+        debug: args.verbose && console.info.bind(console),
+        preset: 'angular',
+        path: args.path,
       }, function (err, release) {
+        console.info("BUMP", release);
         if (err) return reject(err)
         else return resolve(release)
       })

--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -133,7 +133,7 @@ function bumpVersion (releaseAs, args) {
       })
     } else {
       conventionalRecommendedBump({
-        debug: args.verbose && console.info.bind(console),
+        debug: args.verbose && console.info.bind(console, 'conventional-recommended-bump'),
         preset: 'angular',
         path: args.path
       }, function (err, release) {

--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -135,9 +135,8 @@ function bumpVersion (releaseAs, args) {
       conventionalRecommendedBump({
         debug: args.verbose && console.info.bind(console),
         preset: 'angular',
-        path: args.path,
+        path: args.path
       }, function (err, release) {
-        console.info("BUMP", release);
         if (err) return reject(err)
         else return resolve(release)
       })

--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -30,7 +30,7 @@ function outputChangelog (args, newVersion) {
     var context
     if (args.dryRun) context = { version: newVersion }
     var changelogStream = conventionalChangelog({
-      debug: args.verbose && console.info.bind(console, "standard-version"),
+      debug: args.verbose && console.info.bind(console, 'conventional-changelog'),
       preset: 'angular',
       tagPrefix: args.tagPrefix
     }, context, { merges: null, path: args.path })

--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -31,7 +31,7 @@ function outputChangelog (args, newVersion) {
     if (args.dryRun) context = { version: newVersion }
     var changelogStream = conventionalChangelog({
       debug: args.verbose && console.info.bind(console, 'conventional-changelog'),
-      preset: 'angular',
+      preset: args.preset || 'angular',
       tagPrefix: args.tagPrefix
     }, context, { merges: null, path: args.path })
       .on('error', function (err) {

--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -30,9 +30,10 @@ function outputChangelog (args, newVersion) {
     var context
     if (args.dryRun) context = { version: newVersion }
     var changelogStream = conventionalChangelog({
+      debug: args.verbose && console.info.bind(console, "standard-version"),
       preset: 'angular',
       tagPrefix: args.tagPrefix
-    }, context, { merges: null })
+    }, context, { merges: null, path: args.path })
       .on('error', function (err) {
         return reject(err)
       })


### PR DESCRIPTION
Path option will be passed down to:

  1. `conventional-recommended-bump` to produce correct version
  2. `conventional-changelog` to produce correct changelog

Specifically it will be used by `git-raw-commits` package.