### PR TITLE
feat: preserve formatting when writing to package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
-const latestSemverTag = require('./lib/latest-semver-tag')
-const path = require('path')
-const printError = require('./lib/print-error')
-
 const bump = require('./lib/lifecycles/bump')
 const changelog = require('./lib/lifecycles/changelog')
 const commit = require('./lib/lifecycles/commit')
+const fs = require('fs')
+const latestSemverTag = require('./lib/latest-semver-tag')
+const path = require('path')
+const printError = require('./lib/print-error')
 const tag = require('./lib/lifecycles/tag')
 
 module.exports = function standardVersion (argv) {
@@ -13,7 +13,8 @@ module.exports = function standardVersion (argv) {
     if (pkg) return
     var pkgPath = path.resolve(process.cwd(), filename)
     try {
-      pkg = require(pkgPath)
+      var data = fs.readFileSync(pkgPath, 'utf8')
+      pkg = JSON.parse(data)
     } catch (err) {}
   })
   let newVersion

--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -3,12 +3,15 @@
 const chalk = require('chalk')
 const checkpoint = require('../checkpoint')
 const conventionalRecommendedBump = require('conventional-recommended-bump')
+const detectIndent = require('detect-indent')
+const detectNewline = require('detect-newline')
 const figures = require('figures')
 const fs = require('fs')
 const DotGitignore = require('dotgitignore')
 const path = require('path')
 const runLifecycleScript = require('../run-lifecycle-script')
 const semver = require('semver')
+const stringifyPackage = require('stringify-package')
 const writeFile = require('../write-file')
 
 var configsToUpdate = {}
@@ -160,11 +163,14 @@ function updateConfigs (args, newVersion) {
       if (dotgit.ignore(configPath)) return
       var stat = fs.lstatSync(configPath)
       if (stat.isFile()) {
-        var config = require(configPath)
+        var data = fs.readFileSync(configPath, 'utf8')
+        var indent = detectIndent(data).indent
+        var newline = detectNewline(data)
+        var config = JSON.parse(data)
         var filename = path.basename(configPath)
         checkpoint(args, 'bumping version in ' + filename + ' from %s to %s', [config.version, newVersion])
         config.version = newVersion
-        writeFile(args, configPath, JSON.stringify(config, null, 2) + '\n')
+        writeFile(args, configPath, stringifyPackage(config, indent, newline))
         // flag any config files that we modify the version # for
         // as having been updated.
         configsToUpdate[configPath] = true

--- a/package.json
+++ b/package.json
@@ -41,10 +41,13 @@
     "chalk": "^2.4.1",
     "conventional-changelog": "^3.0.5",
     "conventional-recommended-bump": "^4.0.4",
+    "detect-indent": "^5.0.0",
+    "detect-newline": "^2.1.0",
     "dotgitignore": "^1.0.3",
     "figures": "^2.0.0",
     "fs-access": "^1.0.0",
     "semver": "^5.2.0",
+    "stringify-package": "^1.0.0",
     "yargs": "^12.0.2"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -95,16 +95,6 @@ function initInTempFolder () {
   shell.cd('tmp')
   shell.exec('git init')
   commit('root-commit')
-  ;['package.json',
-    'manifest.json',
-    'bower.json'
-  ].forEach(metadata => {
-    try {
-      delete require.cache[require.resolve(path.join(process.cwd(), metadata))]
-    } catch (err) {
-      // we haven't loaded the metadata file yet.
-    }
-  })
   writePackageJson('1.0.0')
 }
 
@@ -605,6 +595,44 @@ describe('cli', function () {
 
     var pkgJson = fs.readFileSync('package.json', 'utf-8')
     pkgJson.should.equal(['{', '  "version": "1.0.1"', '}', ''].join('\n'))
+  })
+
+  it('preserves indentation of tabs in package.json', function () {
+    var indentation = '\t'
+    var newPkgJson = ['{', indentation + '"version": "1.0.0"', '}', ''].join('\n')
+    fs.writeFileSync('package.json', newPkgJson, 'utf-8')
+
+    execCli().code.should.equal(0)
+    var pkgJson = fs.readFileSync('package.json', 'utf-8')
+    pkgJson.should.equal(['{', indentation + '"version": "1.0.1"', '}', ''].join('\n'))
+  })
+
+  it('preserves indentation of spaces in package.json', function () {
+    var indentation = '     '
+    var newPkgJson = ['{', indentation + '"version": "1.0.0"', '}', ''].join('\n')
+    fs.writeFileSync('package.json', newPkgJson, 'utf-8')
+
+    execCli().code.should.equal(0)
+    var pkgJson = fs.readFileSync('package.json', 'utf-8')
+    pkgJson.should.equal(['{', indentation + '"version": "1.0.1"', '}', ''].join('\n'))
+  })
+
+  it('preserves line feed in package.json', function () {
+    var newPkgJson = ['{', '  "version": "1.0.0"', '}', ''].join('\n')
+    fs.writeFileSync('package.json', newPkgJson, 'utf-8')
+
+    execCli().code.should.equal(0)
+    var pkgJson = fs.readFileSync('package.json', 'utf-8')
+    pkgJson.should.equal(['{', '  "version": "1.0.1"', '}', ''].join('\n'))
+  })
+
+  it('preserves carriage return + line feed in package.json', function () {
+    var newPkgJson = ['{', '  "version": "1.0.0"', '}', ''].join('\r\n')
+    fs.writeFileSync('package.json', newPkgJson, 'utf-8')
+
+    execCli().code.should.equal(0)
+    var pkgJson = fs.readFileSync('package.json', 'utf-8')
+    pkgJson.should.equal(['{', '  "version": "1.0.1"', '}', ''].join('\r\n'))
   })
 
   it('does not run git hooks if the --no-verify flag is passed', function () {


### PR DESCRIPTION
This PR implements a feature (or maybe it's a fix?) to get `standard-version` to preserve the indentation and 
line feed of `package.json` instead of overriding the user's preferred format with 2 space indentation. (See #43)

`detect-indent` and `detect-newline` are used to figure out the current indentation of `package.json`. This is done in an identical way to how `npm` handles writing changes to `package.json`.

Notable internal change:
1. `package.json` is no longer loaded with `require()`. While it should be functionally identical, in order to detect the formatting, the file to be read in as plain text. This caused certain tests to fail since the require cache wasn't updated during the bump, resulting in additional places where the cache needed to be deleted between invocations of the CLI in these tests. By using `fs.readFileSync()` in both places in the code where `package.json` is read instead of `require()`, the deletion of the `require` cache in the tests is no longer necessary for them to work.