### PR TITLE
Bump deps

### DIFF
--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -1,4 +1,3 @@
-const accessSync = require('fs-access').sync
 const chalk = require('chalk')
 const checkpoint = require('../checkpoint')
 const conventionalChangelog = require('conventional-changelog')
@@ -52,7 +51,7 @@ function outputChangelog (args, newVersion) {
 
 function createIfMissing (args) {
   try {
-    accessSync(args.infile, fs.F_OK)
+    fs.accessSync(args.infile)
   } catch (err) {
     if (err.code === 'ENOENT') {
       checkpoint(args, 'created %s', [args.infile])

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "conventional-recommended-bump": "^4.0.4",
     "dotgitignore": "^2.0.0",
     "figures": "^2.0.0",
-    "fs-access": "^1.0.0",
     "semver": "^5.2.0",
     "yargs": "^12.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "git+https://github.com/conventional-changelog/standard-version.git"
   },
   "engines": {
-    "node": ">=4.0"
+    "node": ">=6"
   },
   "keywords": [
     "conventional-changelog",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "chalk": "^2.4.1",
     "conventional-changelog": "^3.0.5",
     "conventional-recommended-bump": "^4.0.4",
-    "dotgitignore": "^1.0.3",
+    "dotgitignore": "^2.0.0",
     "figures": "^2.0.0",
     "fs-access": "^1.0.0",
     "semver": "^5.2.0",


### PR DESCRIPTION
- Updates engines to `>=6` (missed doing that in #274 I guess?)
- Bumped dotgitignore which just removes Node.js 4 compat
- Removed fs-access which have been deprecated, it's in the standard fs package now