### PR TITLE
fix: update search pattern for finding changelog sections

### DIFF
--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -23,8 +23,9 @@ function outputChangelog (args, newVersion) {
     var header = '# Change Log\n\nAll notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.\n'
     var oldContent = args.dryRun ? '' : fs.readFileSync(args.infile, 'utf-8')
     // find the position of the last release and remove header:
-    if (oldContent.indexOf('<a name=') !== -1) {
-      oldContent = oldContent.substring(oldContent.indexOf('<a name='))
+    const changelogSectionRegExp = /<a name=|##? \[?[0-9]+\.[0-9]+\.[0-9]+\]?/
+    if (oldContent.search(changelogSectionRegExp) !== -1) {
+      oldContent = oldContent.substring(oldContent.search(changelogSectionRegExp))
     }
     var content = ''
     var context


### PR DESCRIPTION
This pull request updates the search pattern for finding changelog sections to account for section headers that don't have anchors (in addition to section headers that _do_ have anchors).

This change is needed because Conventional Changelog [removed anchors from changelog templates](https://github.com/conventional-changelog/conventional-changelog/commit/346f24f0f8d92b64ed62658796d1876a52ec3ab3). That change has not been included in the conventional-changelog dependency for `standard-version` yet, but will need to be addressed before it can be. Additionally, manually edited changelogs may not include these anchors, which means that this change will make it easier to adopt `standard-version` into existing projects.