### PR TITLE
Register missing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "dotgitignore": "^1.0.3",
     "figures": "^2.0.0",
     "fs-access": "^1.0.0",
+    "git-semver-tags": "^2.0.2",
     "semver": "^5.2.0",
     "yargs": "^12.0.2"
   },


### PR DESCRIPTION
`dependencies` in package.json doesn't list some direct dependencies of this project (now it works only by chance, that deep level dependencies are installed top level)

(as a side note: such errors could be avoided by relying on [import/no-extraneous-dependencies](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md) eslint rule)