### PR TITLE
chore: Disable gpg signing in temporary test repositories.

### DIFF
--- a/test.js
+++ b/test.js
@@ -94,6 +94,7 @@ function initInTempFolder () {
   shell.mkdir('tmp')
   shell.cd('tmp')
   shell.exec('git init')
+  shell.exec('git config commit.gpgSign false')
   commit('root-commit')
   writePackageJson('1.0.0')
 }


### PR DESCRIPTION
My ~/.gitconfig has `commit.gpgSign=true`, earlier I ran the test when
my gpg-agent was not active and got prompted for my gpg password.  This
adds config to the temporary test repositories to avoid automatic
signing of commits.