### PR TITLE
fix: correct changelog spelling in header

### DIFF
--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -20,7 +20,7 @@ module.exports = function (args, newVersion) {
 function outputChangelog (args, newVersion) {
   return new Promise((resolve, reject) => {
     createIfMissing(args)
-    var header = '# Change Log\n\nAll notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.\n'
+    var header = '# Changelog\n\nAll notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.\n'
     var oldContent = args.dryRun ? '' : fs.readFileSync(args.infile, 'utf-8')
     // find the position of the last release and remove header:
     const changelogSectionRegExp = /<a name=|##? \[?[0-9]+\.[0-9]+\.[0-9]+\]?/


### PR DESCRIPTION
In my opinion this is just a spelling mistake and not a breaking change.