### PR TITLE
fix(commit): don't try to process or to add changelog if it's skipped

### DIFF
--- a/lib/lifecycles/commit.js
+++ b/lib/lifecycles/commit.js
@@ -19,15 +19,26 @@ module.exports = function (args, newVersion) {
 
 function execCommit (args, newVersion) {
   let msg = 'committing %s'
-  let paths = [args.infile]
+  let paths = []
   let verify = args.verify === false || args.n ? '--no-verify ' : ''
   let toAdd = ''
+
+  // only start with a pre-populated paths list when CHANGELOG processing is not skipped
+  if (!args.skip.changelog) {
+    paths = [args.infile]
+    toAdd += ' ' + args.infile
+  }
+
   // commit any of the config files that we've updated
   // the version # for.
   Object.keys(bump.getUpdatedConfigs()).forEach(function (p) {
-    msg += ' and %s'
     paths.unshift(p)
     toAdd += ' ' + path.relative(process.cwd(), p)
+
+    // account for multiple files in the output message
+    if (paths.length > 1) {
+      msg += ' and %s'
+    }
   })
 
   if (args.commitAll) {
@@ -36,8 +47,14 @@ function execCommit (args, newVersion) {
   }
 
   checkpoint(args, msg, paths)
-  return runExec(args, 'git add' + toAdd + ' ' + args.infile)
+
+  // nothing to do, exit without commit anything
+  if (args.skip.changelog && args.skip.bump && toAdd.length === 0) {
+    return Promise.resolve()
+  }
+
+  return runExec(args, 'git add' + toAdd)
     .then(() => {
-      return runExec(args, 'git commit ' + verify + (args.sign ? '-S ' : '') + (args.commitAll ? '' : (args.infile + toAdd)) + ' -m "' + formatCommitMessage(args.message, newVersion) + '"')
+      return runExec(args, 'git commit ' + verify + (args.sign ? '-S ' : '') + (args.commitAll ? '' : (toAdd)) + ' -m "' + formatCommitMessage(args.message, newVersion) + '"')
     })
 }

--- a/test.js
+++ b/test.js
@@ -149,6 +149,24 @@ describe('cli', function () {
       content.should.match(/first commit/)
       shell.exec('git tag').stdout.should.match(/1\.0\.1/)
     })
+
+    it('skipping changelog will not create a changelog file', function () {
+      writePackageJson('1.0.0')
+
+      commit('feat: first commit')
+      return execCliAsync('--skip.changelog true')
+        .then(function () {
+          getPackageVersion().should.equal('1.1.0')
+          let fileNotFound = false
+          try {
+            fs.readFileSync('CHANGELOG.md', 'utf-8')
+          } catch (err) {
+            fileNotFound = true
+          }
+
+          fileNotFound.should.equal(true)
+        })
+    })
   })
 
   describe('CHANGELOG.md exists', function () {


### PR DESCRIPTION
If you skip changelog generation standard-version fails to process the remaining checkpoints. This PR provides a fix.

## Fixes
+ Prevent `CHANGELOG.md` or any given `infile` from being added to git when skipped.
+ Prevent `CHANGELOG.md` or any given `infile` from being added to the output when skipped.

## Problem Description 
Given this config:
```
"standard-version": {
    "skip": {
      "changelog": false,
      "tag": true
    }
  },
```

Before
```
✔ bumping version in package.json from 1.0.0 to 1.1.0
✔ committing package.json and CHANGELOG.md
fatal: pathspec 'CHANGELOG.md' did not match any files

Command failed: git add package.json CHANGELOG.md
fatal: pathspec 'CHANGELOG.md' did not match any files
```

After 
```
✔ bumping version in package.json from 1.0.0 to 1.1.0
✔ committing package.json
```

Could not find any tests so I made the changes and tried it locally with the desired result.

Hope this works, thanks for this great tool.
Regards