### PR TITLE
fix: stop suggesting npm publish if package.json was not updated

### DIFF
--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -162,10 +162,8 @@ function bumpVersion (releaseAs, currentVersion, args) {
  */
 function updateConfigs (args, newVersion) {
   const dotgit = DotGitignore()
-  Bump.pkgFiles.concat(Bump.lockFiles).forEach((filename) => {
-    configsToUpdate[path.resolve(process.cwd(), filename)] = false
-  })
-  Object.keys(configsToUpdate).forEach(function (configPath) {
+  Bump.pkgFiles.concat(Bump.lockFiles).forEach(function (filename) {
+    let configPath = path.resolve(process.cwd(), filename)
     try {
       if (dotgit.ignore(configPath)) return
       let stat = fs.lstatSync(configPath)
@@ -174,13 +172,12 @@ function updateConfigs (args, newVersion) {
         let indent = detectIndent(data).indent
         let newline = detectNewline(data)
         let config = JSON.parse(data)
-        let filename = path.basename(configPath)
         checkpoint(args, 'bumping version in ' + filename + ' from %s to %s', [config.version, newVersion])
         config.version = newVersion
         writeFile(args, configPath, stringifyPackage(config, indent, newline))
         // flag any config files that we modify the version # for
         // as having been updated.
-        configsToUpdate[configPath] = true
+        configsToUpdate[filename] = true
       }
     } catch (err) {
       if (err.code !== 'ENOENT') console.warn(err.message)

--- a/lib/lifecycles/commit.js
+++ b/lib/lifecycles/commit.js
@@ -25,11 +25,9 @@ function execCommit (args, newVersion) {
   // commit any of the config files that we've updated
   // the version # for.
   Object.keys(bump.getUpdatedConfigs()).forEach(function (p) {
-    if (bump.getUpdatedConfigs()[p]) {
-      msg += ' and %s'
-      paths.unshift(path.basename(p))
-      toAdd += ' ' + path.relative(process.cwd(), p)
-    }
+    msg += ' and %s'
+    paths.unshift(p)
+    toAdd += ' ' + path.relative(process.cwd(), p)
   })
 
   if (args.commitAll) {

--- a/lib/lifecycles/tag.js
+++ b/lib/lifecycles/tag.js
@@ -1,3 +1,4 @@
+const bump = require('../lifecycles/bump')
 const chalk = require('chalk')
 const checkpoint = require('../checkpoint')
 const figures = require('figures')
@@ -28,7 +29,7 @@ function execTag (newVersion, pkgPrivate, args) {
     .then(() => runExec('', 'git rev-parse --abbrev-ref HEAD'))
     .then((currentBranch) => {
       let message = 'git push --follow-tags origin ' + currentBranch.trim()
-      if (pkgPrivate !== true) {
+      if (pkgPrivate !== true && bump.getUpdatedConfigs()['package.json']) {
         message += ' && npm publish'
         if (args.prerelease !== undefined) {
           if (args.prerelease === '') {

--- a/test.js
+++ b/test.js
@@ -1030,6 +1030,13 @@ describe('standard-version', function () {
           output.stdout.should.include('v5.1.0')
         })
     })
+
+    it('does not display `npm publish` if there is no package.json', function () {
+      shell.rm('package.json')
+      const result = execCli()
+      result.code.should.equal(0)
+      result.stdout.should.not.match(/npm publish/)
+    })
   })
 
   describe('configuration', () => {


### PR DESCRIPTION
`standard-version@5.0.0` introduced git tag fallback, but it is still suggesting `npm publish` even if `package.json` was not updated.

Added a check so it doesn't. Could later be generalized for bower and composer, etc...?

Did a small refactor in `bump.js` so that the check would be simpler.