### PR TITLE
chore: Updates `var` usage to `let`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "extends": "standard",
+  "rules": {
+    "no-var": "error"
+  }
+}

--- a/command.js
+++ b/command.js
@@ -1,4 +1,4 @@
-var defaults = require('./defaults')
+let defaults = require('./defaults')
 
 module.exports = require('yargs')
   .usage('Usage: $0 [options]')

--- a/index.js
+++ b/index.js
@@ -11,9 +11,9 @@ module.exports = function standardVersion (argv) {
   let pkg
   bump.pkgFiles.forEach((filename) => {
     if (pkg) return
-    var pkgPath = path.resolve(process.cwd(), filename)
+    let pkgPath = path.resolve(process.cwd(), filename)
     try {
-      var data = fs.readFileSync(pkgPath, 'utf8')
+      let data = fs.readFileSync(pkgPath, 'utf8')
       pkg = JSON.parse(data)
     } catch (err) {}
   })

--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -14,7 +14,7 @@ const semver = require('semver')
 const stringifyPackage = require('stringify-package')
 const writeFile = require('../write-file')
 
-var configsToUpdate = {}
+let configsToUpdate = {}
 
 function Bump (args, version) {
   // reset the cache of updated config files each
@@ -22,7 +22,7 @@ function Bump (args, version) {
   configsToUpdate = {}
 
   if (args.skip.bump) return Promise.resolve()
-  var newVersion = version
+  let newVersion = version
   return runLifecycleScript(args, 'prerelease')
     .then(runLifecycleScript.bind(this, args, 'prebump'))
     .then((stdout) => {
@@ -31,7 +31,7 @@ function Bump (args, version) {
     })
     .then((release) => {
       if (!args.firstRelease) {
-        var releaseType = getReleaseType(args.prerelease, release.releaseType, version)
+        let releaseType = getReleaseType(args.prerelease, release.releaseType, version)
         newVersion = semver.valid(releaseType) || semver.inc(version, releaseType, args.prerelease)
         updateConfigs(args, newVersion)
       } else {
@@ -100,7 +100,7 @@ function isInPrerelease (version) {
   return Array.isArray(semver.prerelease(version))
 }
 
-var TypeList = ['major', 'minor', 'patch'].reverse()
+let TypeList = ['major', 'minor', 'patch'].reverse()
 
 /**
  * extract the in-pre-release type in target version
@@ -109,8 +109,8 @@ var TypeList = ['major', 'minor', 'patch'].reverse()
  * @return {string}
  */
 function getCurrentActiveType (version) {
-  var typelist = TypeList
-  for (var i = 0; i < typelist.length; i++) {
+  let typelist = TypeList
+  for (let i = 0; i < typelist.length; i++) {
     if (semver[typelist[i]](version)) {
       return typelist[i]
     }
@@ -163,13 +163,13 @@ function updateConfigs (args, newVersion) {
   Object.keys(configsToUpdate).forEach(function (configPath) {
     try {
       if (dotgit.ignore(configPath)) return
-      var stat = fs.lstatSync(configPath)
+      let stat = fs.lstatSync(configPath)
       if (stat.isFile()) {
-        var data = fs.readFileSync(configPath, 'utf8')
-        var indent = detectIndent(data).indent
-        var newline = detectNewline(data)
-        var config = JSON.parse(data)
-        var filename = path.basename(configPath)
+        let data = fs.readFileSync(configPath, 'utf8')
+        let indent = detectIndent(data).indent
+        let newline = detectNewline(data)
+        let config = JSON.parse(data)
+        let filename = path.basename(configPath)
         checkpoint(args, 'bumping version in ' + filename + ' from %s to %s', [config.version, newVersion])
         config.version = newVersion
         writeFile(args, configPath, stringifyPackage(config, indent, newline))

--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -20,16 +20,16 @@ module.exports = function (args, newVersion) {
 function outputChangelog (args, newVersion) {
   return new Promise((resolve, reject) => {
     createIfMissing(args)
-    var header = '# Change Log\n\nAll notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.\n'
-    var oldContent = args.dryRun ? '' : fs.readFileSync(args.infile, 'utf-8')
+    let header = '# Change Log\n\nAll notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.\n'
+    let oldContent = args.dryRun ? '' : fs.readFileSync(args.infile, 'utf-8')
     // find the position of the last release and remove header:
     if (oldContent.indexOf('<a name=') !== -1) {
       oldContent = oldContent.substring(oldContent.indexOf('<a name='))
     }
-    var content = ''
-    var context
+    let content = ''
+    let context
     if (args.dryRun) context = { version: newVersion }
-    var changelogStream = conventionalChangelog({
+    let changelogStream = conventionalChangelog({
       debug: args.verbose && console.info.bind(console, 'conventional-changelog'),
       preset: args.preset || 'angular',
       tagPrefix: args.tagPrefix

--- a/lib/lifecycles/commit.js
+++ b/lib/lifecycles/commit.js
@@ -18,10 +18,10 @@ module.exports = function (args, newVersion) {
 }
 
 function execCommit (args, newVersion) {
-  var msg = 'committing %s'
-  var paths = [args.infile]
-  var verify = args.verify === false || args.n ? '--no-verify ' : ''
-  var toAdd = ''
+  let msg = 'committing %s'
+  let paths = [args.infile]
+  let verify = args.verify === false || args.n ? '--no-verify ' : ''
+  let toAdd = ''
   // commit any of the config files that we've updated
   // the version # for.
   Object.keys(bump.getUpdatedConfigs()).forEach(function (p) {

--- a/lib/lifecycles/tag.js
+++ b/lib/lifecycles/tag.js
@@ -17,7 +17,7 @@ module.exports = function (newVersion, pkgPrivate, args) {
 }
 
 function execTag (newVersion, pkgPrivate, args) {
-  var tagOption
+  let tagOption
   if (args.sign) {
     tagOption = '-s '
   } else {
@@ -26,7 +26,7 @@ function execTag (newVersion, pkgPrivate, args) {
   checkpoint(args, 'tagging release %s%s', [args.tagPrefix, newVersion])
   return runExec(args, 'git tag ' + tagOption + args.tagPrefix + newVersion + ' -m "' + formatCommitMessage(args.message, newVersion) + '"')
     .then(() => {
-      var message = 'git push --follow-tags origin master'
+      let message = 'git push --follow-tags origin master'
       if (pkgPrivate !== true) {
         message += ' && npm publish'
         if (args.prerelease !== undefined) {

--- a/lib/run-lifecycle-hook.js
+++ b/lib/run-lifecycle-hook.js
@@ -5,7 +5,7 @@ const runExec = require('./run-exec')
 
 module.exports = function (args, hookName, newVersion, hooks, cb) {
   if (!hooks[hookName]) return Promise.resolve()
-  var command = hooks[hookName] + ' --new-version="' + newVersion + '"'
+  let command = hooks[hookName] + ' --new-version="' + newVersion + '"'
   checkpoint(args, 'Running lifecycle hook "%s"', [hookName])
   checkpoint(args, '- hook command: "%s"', [command], chalk.blue(figures.info))
   return runExec(args, command)

--- a/lib/run-lifecycle-script.js
+++ b/lib/run-lifecycle-script.js
@@ -6,7 +6,7 @@ const runExec = require('./run-exec')
 module.exports = function (args, hookName) {
   const scripts = args.scripts
   if (!scripts || !scripts[hookName]) return Promise.resolve()
-  var command = scripts[hookName]
+  let command = scripts[hookName]
   checkpoint(args, 'Running lifecycle script "%s"', [hookName])
   checkpoint(args, '- execute command: "%s"', [command], chalk.blue(figures.info))
   return runExec(args, command)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "replacement for `npm version` with automatic CHANGELOG generation",
   "bin": "bin/cli.js",
   "scripts": {
-    "pretest": "standard",
+    "pretest": "eslint .",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "test": "nyc mocha --timeout=20000 test.js",
     "release": "bin/cli.js"
@@ -54,11 +54,16 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "coveralls": "^3.0.1",
+    "eslint": "^5.16.0",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-import": "^2.16.0",
+    "eslint-plugin-node": "^8.0.1",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.0",
     "mocha": "^5.2.0",
     "mock-git": "^1.0.3",
     "mockery": "^2.0.0",
     "nyc": "^13.3.0",
-    "shelljs": "^0.7.8",
-    "standard": "^12.0.1"
+    "shelljs": "^0.7.8"
   }
 }

--- a/test.js
+++ b/test.js
@@ -15,7 +15,7 @@ const standardVersion = require('./index')
 
 require('chai').should()
 
-var cliPath = path.resolve(__dirname, './bin/cli.js')
+let cliPath = path.resolve(__dirname, './bin/cli.js')
 
 function branch (branch) {
   shell.exec('git branch ' + branch)
@@ -43,31 +43,31 @@ function execCliAsync (argString) {
 
 function writePackageJson (version, option) {
   option = option || {}
-  var pkg = Object.assign(option, { version: version })
+  let pkg = Object.assign(option, { version: version })
   fs.writeFileSync('package.json', JSON.stringify(pkg), 'utf-8')
 }
 
 function writeBowerJson (version, option) {
   option = option || {}
-  var bower = Object.assign(option, { version: version })
+  let bower = Object.assign(option, { version: version })
   fs.writeFileSync('bower.json', JSON.stringify(bower), 'utf-8')
 }
 
 function writeManifestJson (version, option) {
   option = option || {}
-  var manifest = Object.assign(option, { version: version })
+  let manifest = Object.assign(option, { version: version })
   fs.writeFileSync('manifest.json', JSON.stringify(manifest), 'utf-8')
 }
 
 function writeNpmShrinkwrapJson (version, option) {
   option = option || {}
-  var shrinkwrap = Object.assign(option, { version: version })
+  let shrinkwrap = Object.assign(option, { version: version })
   fs.writeFileSync('npm-shrinkwrap.json', JSON.stringify(shrinkwrap), 'utf-8')
 }
 
 function writePackageLockJson (version, option) {
   option = option || {}
-  var pkgLock = Object.assign(option, { version: version })
+  let pkgLock = Object.assign(option, { version: version })
   fs.writeFileSync('package-lock.json', JSON.stringify(pkgLock), 'utf-8')
 }
 
@@ -82,7 +82,7 @@ function writePostBumpHook (causeError) {
 
 function writeHook (hookName, causeError, script) {
   shell.mkdir('-p', 'scripts')
-  var content = script || 'console.error("' + hookName + ' ran")'
+  let content = script || 'console.error("' + hookName + ' ran")'
   content += causeError ? '\nthrow new Error("' + hookName + '-failure")' : ''
   fs.writeFileSync('scripts/' + hookName + '.js', content, 'utf-8')
   fs.chmodSync('scripts/' + hookName + '.js', '755')
@@ -131,7 +131,7 @@ describe('cli', function () {
 
       execCli().code.should.equal(0)
 
-      var content = fs.readFileSync('CHANGELOG.md', 'utf-8')
+      let content = fs.readFileSync('CHANGELOG.md', 'utf-8')
       content.should.match(/patch release/)
       content.should.not.match(/first commit/)
     })
@@ -143,7 +143,7 @@ describe('cli', function () {
       commit('fix: patch release')
       execCli('--first-release').code.should.equal(0)
 
-      var content = fs.readFileSync('CHANGELOG.md', 'utf-8')
+      let content = fs.readFileSync('CHANGELOG.md', 'utf-8')
       content.should.match(/patch release/)
       content.should.match(/first commit/)
       shell.exec('git tag').stdout.should.match(/1\.0\.1/)
@@ -159,7 +159,7 @@ describe('cli', function () {
       commit('fix: patch release')
 
       execCli().code.should.equal(0)
-      var content = fs.readFileSync('CHANGELOG.md', 'utf-8')
+      let content = fs.readFileSync('CHANGELOG.md', 'utf-8')
       content.should.match(/1\.0\.1/)
       content.should.not.match(/legacy header format/)
     })
@@ -177,8 +177,8 @@ describe('cli', function () {
 
       execCli('--commit-all').code.should.equal(0)
 
-      var content = fs.readFileSync('CHANGELOG.md', 'utf-8')
-      var status = shell.exec('git status --porcelain') // see http://unix.stackexchange.com/questions/155046/determine-if-git-working-directory-is-clean-from-a-script
+      let content = fs.readFileSync('CHANGELOG.md', 'utf-8')
+      let status = shell.exec('git status --porcelain') // see http://unix.stackexchange.com/questions/155046/determine-if-git-working-directory-is-clean-from-a-script
 
       status.should.equal('')
       status.should.not.match(/STUFF.md/)
@@ -195,7 +195,7 @@ describe('cli', function () {
         .then(function (unmock) {
           execCli('--sign').code.should.equal(0)
 
-          var captured = shell.cat('gitcapture.log').stdout.split('\n').map(function (line) {
+          let captured = shell.cat('gitcapture.log').stdout.split('\n').map(function (line) {
             return line ? JSON.parse(line) : line
           })
           captured[captured.length - 3].should.deep.equal(['commit', '-S', 'CHANGELOG.md', 'package.json', '-m', 'chore(release): 1.0.1'])
@@ -209,7 +209,7 @@ describe('cli', function () {
       // mock git by throwing on attempt to commit
       return mockGit('console.error("commit yourself"); process.exit(128);', 'commit')
         .then(function (unmock) {
-          var result = execCli()
+          let result = execCli()
           result.code.should.equal(1)
           result.stderr.should.match(/commit yourself/)
 
@@ -221,7 +221,7 @@ describe('cli', function () {
       // mock git by throwing on attempt to add
       return mockGit('console.error("addition is hard"); process.exit(128);', 'add')
         .then(function (unmock) {
-          var result = execCli()
+          let result = execCli()
           result.code.should.equal(1)
           result.stderr.should.match(/addition is hard/)
 
@@ -233,7 +233,7 @@ describe('cli', function () {
       // mock git by throwing on attempt to commit
       return mockGit('console.error("tag, you\'re it"); process.exit(128);', 'tag')
         .then(function (unmock) {
-          var result = execCli()
+          let result = execCli()
           result.code.should.equal(1)
           result.stderr.should.match(/tag, you're it/)
 
@@ -247,7 +247,7 @@ describe('cli', function () {
         .then(function (unmock) {
           writePackageJson('1.0.0')
 
-          var result = execCli()
+          let result = execCli()
           result.code.should.equal(0)
           result.stderr.should.match(/haha, kidding, this is just a warning/)
 
@@ -270,7 +270,7 @@ describe('cli', function () {
         fs.writeFileSync('CHANGELOG.md', 'legacy header format<a name="1.0.0">\n', 'utf-8')
 
         commit('feat: first commit')
-        var result = execCli('--patch')
+        let result = execCli('--patch')
         result.code.should.equal(0)
         result.stderr.should.match(/prerelease ran/)
       })
@@ -287,7 +287,7 @@ describe('cli', function () {
         fs.writeFileSync('CHANGELOG.md', 'legacy header format<a name="1.0.0">\n', 'utf-8')
 
         commit('feat: first commit')
-        var result = execCli('--patch')
+        let result = execCli('--patch')
         result.code.should.equal(1)
         result.stderr.should.match(/prerelease ran/)
       })
@@ -306,7 +306,7 @@ describe('cli', function () {
         fs.writeFileSync('CHANGELOG.md', 'legacy header format<a name="1.0.0">\n', 'utf-8')
 
         commit('feat: first commit')
-        var result = execCli('--patch')
+        let result = execCli('--patch')
         result.stdout.should.match(/9\.9\.9/)
         result.code.should.equal(0)
       })
@@ -325,7 +325,7 @@ describe('cli', function () {
         fs.writeFileSync('CHANGELOG.md', 'legacy header format<a name="1.0.0">\n', 'utf-8')
 
         commit('feat: first commit')
-        var result = execCli('--patch')
+        let result = execCli('--patch')
         result.code.should.equal(0)
         result.stderr.should.match(/postbump ran/)
       })
@@ -342,7 +342,7 @@ describe('cli', function () {
         fs.writeFileSync('CHANGELOG.md', 'legacy header format<a name="1.0.0">\n', 'utf-8')
 
         commit('feat: first commit')
-        var result = execCli('--patch')
+        let result = execCli('--patch')
         result.code.should.equal(1)
         result.stderr.should.match(/postbump-failure/)
       })
@@ -361,7 +361,7 @@ describe('cli', function () {
         fs.writeFileSync('CHANGELOG.md', 'legacy header format<a name="1.0.0">\n', 'utf-8')
 
         commit('feat: first commit')
-        var result = execCli('--patch')
+        let result = execCli('--patch')
         result.code.should.equal(0)
         result.stderr.should.match(/precommit ran/)
       })
@@ -378,7 +378,7 @@ describe('cli', function () {
         fs.writeFileSync('CHANGELOG.md', 'legacy header format<a name="1.0.0">\n', 'utf-8')
 
         commit('feat: first commit')
-        var result = execCli('--patch')
+        let result = execCli('--patch')
         result.code.should.equal(1)
         result.stderr.should.match(/precommit-failure/)
       })
@@ -395,7 +395,7 @@ describe('cli', function () {
         fs.writeFileSync('CHANGELOG.md', 'legacy header format<a name="1.0.0">\n', 'utf-8')
 
         commit('feat: first commit')
-        var result = execCli('--patch')
+        let result = execCli('--patch')
         result.code.should.equal(0)
         shell.exec('git log --oneline -n1').should.match(/delivers #222/)
       })
@@ -450,11 +450,11 @@ describe('cli', function () {
     })
 
     describe('release-types', function () {
-      var regularTypes = ['major', 'minor', 'patch']
+      let regularTypes = ['major', 'minor', 'patch']
 
       regularTypes.forEach(function (type) {
         it('creates a ' + type + ' release', function () {
-          var originVer = '1.0.0'
+          let originVer = '1.0.0'
           writePackageJson(originVer)
           fs.writeFileSync('CHANGELOG.md', 'legacy header format<a name="1.0.0">\n', 'utf-8')
 
@@ -462,7 +462,7 @@ describe('cli', function () {
 
           return execCliAsync('--release-as ' + type)
             .then(function () {
-              var version = {
+              let version = {
                 major: semver.major(originVer),
                 minor: semver.minor(originVer),
                 patch: semver.patch(originVer)
@@ -478,7 +478,7 @@ describe('cli', function () {
       // this is for pre-releases
       regularTypes.forEach(function (type) {
         it('creates a pre' + type + ' release', function () {
-          var originVer = '1.0.0'
+          let originVer = '1.0.0'
           writePackageJson(originVer)
           fs.writeFileSync('CHANGELOG.md', 'legacy header format<a name="1.0.0">\n', 'utf-8')
 
@@ -486,7 +486,7 @@ describe('cli', function () {
 
           return execCliAsync('--release-as ' + type + ' --prerelease ' + type)
             .then(function () {
-              var version = {
+              let version = {
                 major: semver.major(originVer),
                 minor: semver.minor(originVer),
                 patch: semver.patch(originVer)
@@ -502,7 +502,7 @@ describe('cli', function () {
 
     describe('release-as-exact', function () {
       it('releases as v100.0.0', function () {
-        var originVer = '1.0.0'
+        let originVer = '1.0.0'
         writePackageJson(originVer)
         fs.writeFileSync('CHANGELOG.md', 'legacy header format<a name="1.0.0">\n', 'utf-8')
 
@@ -515,7 +515,7 @@ describe('cli', function () {
       })
 
       it('releases as 200.0.0-amazing', function () {
-        var originVer = '1.0.0'
+        let originVer = '1.0.0'
         writePackageJson(originVer)
         fs.writeFileSync('CHANGELOG.md', 'legacy header format<a name="1.0.0">\n', 'utf-8')
 
@@ -581,7 +581,7 @@ describe('cli', function () {
 
     execCli().code.should.equal(0)
 
-    var content = fs.readFileSync('CHANGELOG.md', 'utf-8')
+    let content = fs.readFileSync('CHANGELOG.md', 'utf-8')
     content.should.match(/this is my fairly long commit message which is testing whether or not we allow for long commit messages/)
   })
 
@@ -601,45 +601,45 @@ describe('cli', function () {
   it('appends line feed at end of package.json', function () {
     execCli().code.should.equal(0)
 
-    var pkgJson = fs.readFileSync('package.json', 'utf-8')
+    let pkgJson = fs.readFileSync('package.json', 'utf-8')
     pkgJson.should.equal(['{', '  "version": "1.0.1"', '}', ''].join('\n'))
   })
 
   it('preserves indentation of tabs in package.json', function () {
-    var indentation = '\t'
-    var newPkgJson = ['{', indentation + '"version": "1.0.0"', '}', ''].join('\n')
+    let indentation = '\t'
+    let newPkgJson = ['{', indentation + '"version": "1.0.0"', '}', ''].join('\n')
     fs.writeFileSync('package.json', newPkgJson, 'utf-8')
 
     execCli().code.should.equal(0)
-    var pkgJson = fs.readFileSync('package.json', 'utf-8')
+    let pkgJson = fs.readFileSync('package.json', 'utf-8')
     pkgJson.should.equal(['{', indentation + '"version": "1.0.1"', '}', ''].join('\n'))
   })
 
   it('preserves indentation of spaces in package.json', function () {
-    var indentation = '     '
-    var newPkgJson = ['{', indentation + '"version": "1.0.0"', '}', ''].join('\n')
+    let indentation = '     '
+    let newPkgJson = ['{', indentation + '"version": "1.0.0"', '}', ''].join('\n')
     fs.writeFileSync('package.json', newPkgJson, 'utf-8')
 
     execCli().code.should.equal(0)
-    var pkgJson = fs.readFileSync('package.json', 'utf-8')
+    let pkgJson = fs.readFileSync('package.json', 'utf-8')
     pkgJson.should.equal(['{', indentation + '"version": "1.0.1"', '}', ''].join('\n'))
   })
 
   it('preserves line feed in package.json', function () {
-    var newPkgJson = ['{', '  "version": "1.0.0"', '}', ''].join('\n')
+    let newPkgJson = ['{', '  "version": "1.0.0"', '}', ''].join('\n')
     fs.writeFileSync('package.json', newPkgJson, 'utf-8')
 
     execCli().code.should.equal(0)
-    var pkgJson = fs.readFileSync('package.json', 'utf-8')
+    let pkgJson = fs.readFileSync('package.json', 'utf-8')
     pkgJson.should.equal(['{', '  "version": "1.0.1"', '}', ''].join('\n'))
   })
 
   it('preserves carriage return + line feed in package.json', function () {
-    var newPkgJson = ['{', '  "version": "1.0.0"', '}', ''].join('\r\n')
+    let newPkgJson = ['{', '  "version": "1.0.0"', '}', ''].join('\r\n')
     fs.writeFileSync('package.json', newPkgJson, 'utf-8')
 
     execCli().code.should.equal(0)
-    var pkgJson = fs.readFileSync('package.json', 'utf-8')
+    let pkgJson = fs.readFileSync('package.json', 'utf-8')
     pkgJson.should.equal(['{', '  "version": "1.0.1"', '}', ''].join('\r\n'))
   })
 
@@ -653,7 +653,7 @@ describe('cli', function () {
   })
 
   it('does not print output when the --silent flag is passed', function () {
-    var result = execCli('--silent')
+    let result = execCli('--silent')
     result.code.should.equal(0)
     result.stdout.should.equal('')
     result.stderr.should.equal('')
@@ -662,13 +662,13 @@ describe('cli', function () {
   it('does not display `npm publish` if the package is private', function () {
     writePackageJson('1.0.0', { private: true })
 
-    var result = execCli()
+    let result = execCli()
     result.code.should.equal(0)
     result.stdout.should.not.match(/npm publish/)
   })
 
   it('includes merge commits', function () {
-    var branchName = 'new-feature'
+    let branchName = 'new-feature'
     commit('feat: first commit')
     shell.exec('git tag -a v1.0.0 -m "my awesome first release"')
     branch(branchName)
@@ -679,10 +679,10 @@ describe('cli', function () {
 
     execCli().code.should.equal(0)
 
-    var content = fs.readFileSync('CHANGELOG.md', 'utf-8')
+    let content = fs.readFileSync('CHANGELOG.md', 'utf-8')
     content.should.match(/new feature from branch/)
 
-    var pkgJson = fs.readFileSync('package.json', 'utf-8')
+    let pkgJson = fs.readFileSync('package.json', 'utf-8')
     pkgJson.should.equal(['{', '  "version": "1.1.0"', '}', ''].join('\n'))
   })
 
@@ -694,7 +694,7 @@ describe('cli', function () {
     })
 
     commit('feat: first commit')
-    var result = execCli()
+    let result = execCli()
     result.code.should.equal(1)
     result.stderr.should.match(/scripts must be an object/)
   })
@@ -707,7 +707,7 @@ describe('cli', function () {
     })
 
     commit('feat: first commit')
-    var result = execCli()
+    let result = execCli()
     result.code.should.equal(1)
     result.stderr.should.match(/skip must be an object/)
   })
@@ -747,7 +747,7 @@ describe('standard-version', function () {
     beforeEach(function () {
       mockery.enable({ warnOnUnregistered: false, useCleanCache: true })
       mockery.registerMock('conventional-changelog', function () {
-        var readable = new stream.Readable({ objectMode: true })
+        let readable = new stream.Readable({ objectMode: true })
         readable._read = function () {
         }
         setImmediate(readable.emit.bind(readable), 'error', new Error('changelog err'))
@@ -894,7 +894,7 @@ describe('standard-version', function () {
       return execCliAsync('--skip.bump true --skip.changelog true')
         .then(function () {
           getPackageVersion().should.equal('1.0.0')
-          var content = fs.readFileSync('CHANGELOG.md', 'utf-8')
+          let content = fs.readFileSync('CHANGELOG.md', 'utf-8')
           content.should.equal(changelogContent)
         })
     })
@@ -908,7 +908,7 @@ describe('standard-version', function () {
       return execCliAsync('--skip.commit true')
         .then(function () {
           getPackageVersion().should.equal('1.1.0')
-          var content = fs.readFileSync('CHANGELOG.md', 'utf-8')
+          let content = fs.readFileSync('CHANGELOG.md', 'utf-8')
           content.should.match(/new feature from branch/)
           // check last commit message
           shell.exec('git log --oneline -n1').stdout.should.match(/feat: new feature from branch/)


### PR DESCRIPTION
- No longer uses `standard` directly, instead uses the [recommmend manual configuration](https://github.com/standard/eslint-config-standard) to allow for the addition of the [`no-var`](https://eslint.org/docs/rules/no-var) eslint rule.
- Uses `eslint . --fix` after the configuration update to swap `var` usage to `let`

see #276 