### PR TITLE
feats: adds new configurable conventionalcommits preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [6.0.4](https://github.com/conventional-changelog/standard-version/compare/v6.0.3...v6.0.4) (2019-05-05)
+
+
+
 ## [6.0.3](https://github.com/conventional-changelog/standard-version/compare/v6.0.2...v6.0.3) (2019-05-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,41 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [6.0.5](https://github.com/conventional-changelog/standard-version/compare/v6.0.4...v6.0.5) (2019-05-05)
-
-
-
-## [6.0.4](https://github.com/conventional-changelog/standard-version/compare/v6.0.3...v6.0.4) (2019-05-05)
-
-
-
-## [6.0.3](https://github.com/conventional-changelog/standard-version/compare/v6.0.2...v6.0.3) (2019-05-05)
-
-
-
-## [6.0.2](https://github.com/conventional-changelog/standard-version/compare/v6.0.1...v6.0.2) (2019-05-05)
-
-
-
-## [6.0.1](https://github.com/conventional-changelog/standard-version/compare/v6.0.0...v6.0.1) (2019-05-05)
-
-
-
-# [6.0.0](https://github.com/conventional-changelog/standard-version/compare/v5.0.1...v6.0.0) (2019-05-05)
-
-
-### Features
-
-* adds new conventionalcommits configurable preset ([289700c](https://github.com/conventional-changelog/standard-version/commit/289700c))
-* update commit msg for when using commitAll ([#320](https://github.com/conventional-changelog/standard-version/issues/320)) ([74a040a](https://github.com/conventional-changelog/standard-version/commit/74a040a))
-
-
-### BREAKING CHANGES
-
-* we are moving from the angular to the conventionalcommits preset.
-
-
-
 ## [5.0.2](https://github.com/conventional-changelog/standard-version/compare/v5.0.1...v5.0.2) (2019-03-16)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+# [1.1.0](https://github.com/conventional-changelog/standard-version/compare/v5.0.2...v1.1.0) (2019-04-10)
+
+
+### Features
+
+* update commit msg for when using commitAll ([#320](https://github.com/conventional-changelog/standard-version/issues/320)) ([74a040a](https://github.com/conventional-changelog/standard-version/commit/74a040a))
+
+
+
 ## [5.0.2](https://github.com/conventional-changelog/standard-version/compare/v5.0.1...v5.0.2) (2019-03-16)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [6.0.1](https://github.com/conventional-changelog/standard-version/compare/v6.0.0...v6.0.1) (2019-05-05)
+
+
+
 # [6.0.0](https://github.com/conventional-changelog/standard-version/compare/v5.0.1...v6.0.0) (2019-05-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [6.0.3](https://github.com/conventional-changelog/standard-version/compare/v6.0.2...v6.0.3) (2019-05-05)
+
+
+
 ## [6.0.2](https://github.com/conventional-changelog/standard-version/compare/v6.0.1...v6.0.2) (2019-05-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+# [6.0.0](https://github.com/conventional-changelog/standard-version/compare/v5.0.1...v6.0.0) (2019-05-05)
+
+
+### Features
+
+* adds new conventionalcommits configurable preset ([289700c](https://github.com/conventional-changelog/standard-version/commit/289700c))
+* update commit msg for when using commitAll ([#320](https://github.com/conventional-changelog/standard-version/issues/320)) ([74a040a](https://github.com/conventional-changelog/standard-version/commit/74a040a))
+
+
+### BREAKING CHANGES
+
+* we are moving from the angular to the conventionalcommits preset.
+
+
+
 ## [5.0.2](https://github.com/conventional-changelog/standard-version/compare/v5.0.1...v5.0.2) (2019-03-16)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [6.0.5](https://github.com/conventional-changelog/standard-version/compare/v6.0.4...v6.0.5) (2019-05-05)
+
+
+
 ## [6.0.4](https://github.com/conventional-changelog/standard-version/compare/v6.0.3...v6.0.4) (2019-05-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [6.0.2](https://github.com/conventional-changelog/standard-version/compare/v6.0.1...v6.0.2) (2019-05-05)
+
+
+
 ## [6.0.1](https://github.com/conventional-changelog/standard-version/compare/v6.0.0...v6.0.1) (2019-05-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-# [1.1.0](https://github.com/conventional-changelog/standard-version/compare/v5.0.2...v1.1.0) (2019-04-10)
-
-
-### Features
-
-* update commit msg for when using commitAll ([#320](https://github.com/conventional-changelog/standard-version/issues/320)) ([74a040a](https://github.com/conventional-changelog/standard-version/commit/74a040a))
-
-
-
 ## [5.0.2](https://github.com/conventional-changelog/standard-version/compare/v5.0.1...v5.0.2) (2019-03-16)
 
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,39 @@ Now you can use `standard-version` in place of `npm version`.
 
 This has the benefit of allowing you to use `standard-version` on any repo/package without adding a dev dependency to each one.
 
+## Configuration
+
+You can configure `standard-version` either by:
+
+1. Placing a `standard-version` stanza in your `package.json` (assuming
+   your project is JavaScript).
+1. Creating a `.versionrc` or `.versionrc.json`.
+
+Any of the command line paramters accepted by `standard-version` can instead
+be provided via configuration.
+
+### Customizing CHANGELOG Generation
+
+By default, `standard-version` uses the [conventionalcommits preset](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-conventionalcommits).
+
+This preset:
+
+* adheres closely to the [conventionalcommits.org](https://www.conventionalcommits.org)
+  specification.
+* is highly configurable, following the configuration specification
+  [maintained here](https://github.com/conventional-changelog/conventional-changelog-config-spec).
+  * _we've documented these config settings as a recommendation to other tooling makers._
+
+There are a variety of dials and knobs you can turn related to CHANGELOG generation.
+
+As an example, suppose you're using GitLab, rather than GitHub, you might modify the following variables:
+
+* `commitUrlFormat`: the URL format of commit SHAs detected in commit messages.
+* `compareUrlFormat`: the URL format used to compare two tags.
+* `issueUrlFormat`: the URL format used to link to issues.
+
+Making these URLs match GitLab's format, rather than GitHub's.
+
 ## CLI Usage
 
 ### First Release

--- a/command.js
+++ b/command.js
@@ -4,8 +4,9 @@ const { readFileSync } = require('fs')
 
 const configPath = findUp.sync(['.versionrc', '.version.json'])
 const config = configPath ? JSON.parse(readFileSync(configPath)) : {}
+const spec = require('conventional-changelog-config-spec')
 
-module.exports = require('yargs')
+const yargs = require('yargs')
   .usage('Usage: $0 [options]')
   .option('release-as', {
     alias: 'r',
@@ -107,6 +108,18 @@ module.exports = require('yargs')
   .pkgConf('standard-version')
   .config(config)
   .wrap(97)
+
+Object.keys(spec.properties).forEach(propertyKey => {
+  const property = spec.properties[propertyKey]
+  yargs.option(propertyKey, {
+    type: property.type,
+    describe: property.description,
+    default: property.default,
+    group: 'Preset Configuration:'
+  })
+})
+
+module.exports = yargs
 
 // TODO: yargs should be populated with keys/descriptions from
 // https://github.com/conventional-changelog/conventional-changelog-config-spec

--- a/command.js
+++ b/command.js
@@ -1,4 +1,9 @@
-let defaults = require('./defaults')
+const findUp = require('find-up')
+const defaults = require('./defaults')
+const { readFileSync } = require('fs')
+
+const configPath = findUp.sync(['.versionrc', '.version.json'])
+const config = configPath ? JSON.parse(readFileSync(configPath)) : {}
 
 module.exports = require('yargs')
   .usage('Usage: $0 [options]')
@@ -95,11 +100,13 @@ module.exports = require('yargs')
       return true
     }
   })
-  .version()
   .alias('version', 'v')
-  .help()
   .alias('help', 'h')
   .example('$0', 'Update changelog and tag release')
   .example('$0 -m "%s: see changelog for details"', 'Update changelog and tag release with custom commit message')
   .pkgConf('standard-version')
+  .config(config)
   .wrap(97)
+
+// TODO: yargs should be populated with keys/descriptions from
+// https://github.com/conventional-changelog/conventional-changelog-config-spec

--- a/defaults.json
+++ b/defaults.json
@@ -11,5 +11,5 @@
   "skip": {},
   "dryRun": false,
   "gitTagFallback": true,
-  "preset": "angular"
+  "preset": "conventionalcommits"
 }

--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -9,6 +9,7 @@ const figures = require('figures')
 const fs = require('fs')
 const DotGitignore = require('dotgitignore')
 const path = require('path')
+const presetLoader = require('../preset-loader')
 const runLifecycleScript = require('../run-lifecycle-script')
 const semver = require('semver')
 const stringifyPackage = require('stringify-package')
@@ -137,7 +138,7 @@ function bumpVersion (releaseAs, args) {
     } else {
       conventionalRecommendedBump({
         debug: args.verbose && console.info.bind(console, 'conventional-recommended-bump'),
-        preset: args.preset || 'angular',
+        preset: presetLoader(args),
         path: args.path
       }, function (err, release) {
         if (err) return reject(err)

--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -3,6 +3,7 @@ const chalk = require('chalk')
 const checkpoint = require('../checkpoint')
 const conventionalChangelog = require('conventional-changelog')
 const fs = require('fs')
+const presetLoader = require('../preset-loader')
 const runLifecycleScript = require('../run-lifecycle-script')
 const writeFile = require('../write-file')
 
@@ -32,7 +33,7 @@ function outputChangelog (args, newVersion) {
     if (args.dryRun) context = { version: newVersion }
     let changelogStream = conventionalChangelog({
       debug: args.verbose && console.info.bind(console, 'conventional-changelog'),
-      preset: args.preset || 'angular',
+      preset: presetLoader(args),
       tagPrefix: args.tagPrefix
     }, context, { merges: null, path: args.path })
       .on('error', function (err) {

--- a/lib/preset-loader.js
+++ b/lib/preset-loader.js
@@ -1,0 +1,22 @@
+// TODO: this should be replaced with an object we maintain and
+// describe in: https://github.com/conventional-changelog/conventional-changelog-config-spec
+const spec = {
+  types: {},
+  commitUrlFormat: {},
+  compareUrlFormat: {},
+  issueUrlFormat: {},
+  userUrlFormat: {}
+}
+
+module.exports = (args) => {
+  let preset = args.preset || 'conventionalcommits'
+  if (preset === 'conventionalcommits') {
+    preset = {
+      name: preset
+    }
+    Object.keys(spec).forEach(key => {
+      if (args[key]) preset[key] = args[key]
+    })
+  }
+  return preset
+}

--- a/lib/preset-loader.js
+++ b/lib/preset-loader.js
@@ -1,12 +1,6 @@
 // TODO: this should be replaced with an object we maintain and
 // describe in: https://github.com/conventional-changelog/conventional-changelog-config-spec
-const spec = {
-  types: {},
-  commitUrlFormat: {},
-  compareUrlFormat: {},
-  issueUrlFormat: {},
-  userUrlFormat: {}
-}
+const spec = require('conventional-changelog-config-spec')
 
 module.exports = (args) => {
   let preset = args.preset || 'conventionalcommits'
@@ -14,8 +8,8 @@ module.exports = (args) => {
     preset = {
       name: preset
     }
-    Object.keys(spec).forEach(key => {
-      if (args[key]) preset[key] = args[key]
+    Object.keys(spec.properties).forEach(key => {
+      if (args[key] !== undefined) preset[key] = args[key]
     })
   }
   return preset

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "standard-version",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "replacement for `npm version` with automatic CHANGELOG generation",
   "bin": "bin/cli.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "standard-version",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "replacement for `npm version` with automatic CHANGELOG generation",
   "bin": "bin/cli.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "standard-version",
-  "version": "5.0.2",
+  "version": "6.0.0",
   "description": "replacement for `npm version` with automatic CHANGELOG generation",
   "bin": "bin/cli.js",
   "scripts": {
@@ -40,6 +40,7 @@
   "dependencies": {
     "chalk": "^2.4.1",
     "conventional-changelog": "^3.1.2",
+    "conventional-changelog-config-spec": "^1.0.0",
     "conventional-recommended-bump": "^4.1.1",
     "detect-indent": "^5.0.0",
     "detect-newline": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "standard-version",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "description": "replacement for `npm version` with automatic CHANGELOG generation",
   "bin": "bin/cli.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "standard-version",
-  "version": "5.0.2",
+  "version": "1.1.0",
   "description": "replacement for `npm version` with automatic CHANGELOG generation",
   "bin": "bin/cli.js",
   "scripts": {
-    "pretest": "eslint .",
+    "posttest": "eslint .",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "test": "nyc mocha --timeout=20000 test.js",
     "release": "bin/cli.js"
@@ -45,6 +45,7 @@
     "detect-newline": "^2.1.0",
     "dotgitignore": "^2.1.0",
     "figures": "^2.0.0",
+    "find-up": "^3.0.0",
     "fs-access": "^1.0.0",
     "git-semver-tags": "^2.0.2",
     "semver": "^5.2.0",
@@ -53,7 +54,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "coveralls": "^3.0.1",
+    "coveralls": "^3.0.3",
     "eslint": "^5.16.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "standard-version",
-  "version": "6.0.5",
+  "version": "5.0.2",
   "description": "replacement for `npm version` with automatic CHANGELOG generation",
   "bin": "bin/cli.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "standard-version",
-  "version": "1.1.0",
+  "version": "5.0.2",
   "description": "replacement for `npm version` with automatic CHANGELOG generation",
   "bin": "bin/cli.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "standard-version",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "replacement for `npm version` with automatic CHANGELOG generation",
   "bin": "bin/cli.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "standard-version",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "replacement for `npm version` with automatic CHANGELOG generation",
   "bin": "bin/cli.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   "homepage": "https://github.com/conventional-changelog/standard-version#readme",
   "dependencies": {
     "chalk": "^2.4.1",
-    "conventional-changelog": "^3.0.6",
-    "conventional-recommended-bump": "^4.0.4",
+    "conventional-changelog": "^3.1.2",
+    "conventional-recommended-bump": "^4.1.1",
     "detect-indent": "^5.0.0",
     "detect-newline": "^2.1.0",
     "dotgitignore": "^2.1.0",

--- a/test.js
+++ b/test.js
@@ -668,13 +668,13 @@ describe('cli', function () {
   })
 
   it('does not display `all staged files` without the --commit-all flag', function () {
-    var result = execCli()
+    let result = execCli()
     result.code.should.equal(0)
     result.stdout.should.not.match(/and all staged files/)
   })
 
   it('does display `all staged files` if the --commit-all flag is passed', function () {
-    var result = execCli('--commit-all')
+    let result = execCli('--commit-all')
     result.code.should.equal(0)
     result.stdout.should.match(/and all staged files/)
   })
@@ -987,6 +987,32 @@ describe('standard-version', function () {
           const output = shell.exec('git tag')
           output.stdout.should.include('v5.1.0')
         })
+    })
+  })
+
+  describe('configuration', () => {
+    it('reads config from .versionrc', function () {
+      // we currently skip several replacments in CHANGELOG
+      // generation if repository URL isn't set.
+      //
+      // TODO: consider modifying this logic in conventional-commits
+      // perhaps we should only skip the replacement if we rely on
+      // the {{host}} field?
+      writePackageJson('1.0.0', {
+        repository: {
+          url: 'https://github.com/yargs/yargs.git'
+        }
+      })
+      // write configuration that overrides default issue
+      // URL format.
+      fs.writeFileSync('.versionrc', JSON.stringify({
+        issueUrlFormat: 'http://www.foo.com/{{id}}'
+      }), 'utf-8')
+      commit('feat: another commit addresses issue #1')
+      execCli()
+      // CHANGELOG should have the new issue URL format.
+      const content = fs.readFileSync('CHANGELOG.md', 'utf-8')
+      content.should.include('http://www.foo.com/1')
     })
   })
 })


### PR DESCRIPTION
Int his PR we introduce the conventionalcommits preset, here's why this is cool:

* the conventionalcommits preset is based directly on https://github.com/conventional-commits/conventionalcommits.org/pull/141, allowing us to better handle the slight deviations from angular's convention, e.g., the recent introduction of a `!` character for breaking changes.
* the conventionalcommits preset is highly configurable based on the [specification described here](https://github.com/conventional-changelog/conventional-changelog-config-spec).
  * this will allow `standard-version` to better support options other than GitHub in a well documented, standardized way.

BREAKING CHANGE: switches default preset to conventionalcommits

----

This change is currently blocked by:

* ~https://github.com/conventional-changelog/conventional-changelog/issues/435, which is preventing us from deploying new versions of conventional-changelog.~
* https://github.com/conventional-changelog/conventional-changelog-config-spec/issues/7, which would expose a list of configuration options for standard-version and other tools, so that it's easier to maintain consistent configuration options.