### PR TITLE
docs(readme): describe how to apply no tag prefix at all

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,13 +232,15 @@ standard-version --dry-run
 
 ### Prefix Tags
 
-If you would like to prefix your tags with something, you can do so with the `-t` flag.
+Tags are prefixed with `v` by default. If you would like to prefix your tags with something else, you can do so with the `-t` flag.
 
 ```sh
 standard-version -t @scope/package\@
 ```
 
 This will prefix your tags to look something like `@scope/package@2.0.0`
+
+If you do not want to have any tag prefix you can use the `-t` flag without value.
 
 ### CLI Help
 


### PR DESCRIPTION
The documentation only describes how to apply custom tag prefixes and it does not mention the default tag prefix (`v`) or how to apply no prefix at all.

This PR adds this missing information to the README (based on my own findings, please correct me if I'm wrong).