### PR TITLE
test: use const based on new eslint rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: node_js
 os:
   - linux
-  - osx
   - windows
 node_js:
   - "6"
   - "10"
-  - "stable"
+  - "node"
 before_script:
   - git config --global user.name 'Travis-CI'
   - git config --global user.email 'dummy@example.org'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: node_js
+os:
+  - linux
+  - osx
+  - windows
 node_js:
   - "6"
   - "10"

--- a/test.js
+++ b/test.js
@@ -710,13 +710,13 @@ describe('cli', function () {
   })
 
   it('does not display `all staged files` without the --commit-all flag', function () {
-    let result = execCli()
+    const result = execCli()
     result.code.should.equal(0)
     result.stdout.should.not.match(/and all staged files/)
   })
 
   it('does display `all staged files` if the --commit-all flag is passed', function () {
-    let result = execCli('--commit-all')
+    const result = execCli('--commit-all')
     result.code.should.equal(0)
     result.stdout.should.match(/and all staged files/)
   })


### PR DESCRIPTION
This was caused by tests in #320 using `var` and being merged into the trunk (as-is) just before the new eslint rules (#321)

---

This should fix the build errors we're seeing in some of the latest PRs.