### PR TITLE
fix: git push guideline message with right branch name

### DIFF
--- a/lib/lifecycles/tag.js
+++ b/lib/lifecycles/tag.js
@@ -25,8 +25,9 @@ function execTag (newVersion, pkgPrivate, args) {
   }
   checkpoint(args, 'tagging release %s%s', [args.tagPrefix, newVersion])
   return runExec(args, 'git tag ' + tagOption + args.tagPrefix + newVersion + ' -m "' + formatCommitMessage(args.message, newVersion) + '"')
-    .then(() => {
-      let message = 'git push --follow-tags origin master'
+    .then(() => runExec(args, 'git rev-parse --abbrev-ref HEAD'))
+    .then((currentBranch) => {
+      let message = 'git push --follow-tags origin ' + currentBranch.trim()
       if (pkgPrivate !== true) {
         message += ' && npm publish'
         if (args.prerelease !== undefined) {


### PR DESCRIPTION
git push guideline message at the end is shown as `git push --follow-tags origin master` though the change log is generated in a different branch. People not only use `master` branch but also `develop` or different branch. This fix will add the current branch name instead of master to the message.

closes #249