### PR TITLE
feat!: bump minor rather than major, if release is < 1.0.0

### DIFF
--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -28,7 +28,7 @@ function Bump (args, version) {
     .then(runLifecycleScript.bind(this, args, 'prebump'))
     .then((stdout) => {
       if (stdout && stdout.trim().length) args.releaseAs = stdout.trim()
-      return bumpVersion(args.releaseAs, args)
+      return bumpVersion(args.releaseAs, version, args)
     })
     .then((release) => {
       if (!args.firstRelease) {
@@ -129,16 +129,20 @@ function getTypePriority (type) {
   return TypeList.indexOf(type)
 }
 
-function bumpVersion (releaseAs, args) {
+function bumpVersion (releaseAs, currentVersion, args) {
   return new Promise((resolve, reject) => {
     if (releaseAs) {
       return resolve({
         releaseType: releaseAs
       })
     } else {
+      const presetOptions = presetLoader(args)
+      if (typeof presetOptions === 'object') {
+        if (semver.lt(currentVersion, '1.0.0')) presetOptions.preMajor = true
+      }
       conventionalRecommendedBump({
         debug: args.verbose && console.info.bind(console, 'conventional-recommended-bump'),
-        preset: presetLoader(args),
+        preset: presetOptions,
         path: args.path
       }, function (err, release) {
         if (err) return reject(err)

--- a/test.js
+++ b/test.js
@@ -1059,7 +1059,7 @@ describe('standard-version', function () {
       getPackageVersion().should.equal('0.6.0')
     })
 
-    it('--release-as=major bumps major, if version < 1.0.0', function () {
+    it('bumps major if --release-as=major specified, if version < 1.0.0', function () {
       writePackageJson('0.5.0', {
         repository: {
           url: 'https://github.com/yargs/yargs.git'

--- a/test.js
+++ b/test.js
@@ -1058,5 +1058,16 @@ describe('standard-version', function () {
       execCli()
       getPackageVersion().should.equal('0.6.0')
     })
+
+    it('--release-as=major bumps major, if version < 1.0.0', function () {
+      writePackageJson('0.5.0', {
+        repository: {
+          url: 'https://github.com/yargs/yargs.git'
+        }
+      })
+      commit('feat!: this is a breaking change')
+      execCli('-r major')
+      getPackageVersion().should.equal('1.0.0')
+    })
   })
 })

--- a/test.js
+++ b/test.js
@@ -1034,17 +1034,6 @@ describe('standard-version', function () {
 
   describe('configuration', () => {
     it('reads config from .versionrc', function () {
-      // we currently skip several replacments in CHANGELOG
-      // generation if repository URL isn't set.
-      //
-      // TODO: consider modifying this logic in conventional-commits
-      // perhaps we should only skip the replacement if we rely on
-      // the {{host}} field?
-      writePackageJson('1.0.0', {
-        repository: {
-          url: 'https://github.com/yargs/yargs.git'
-        }
-      })
       // write configuration that overrides default issue
       // URL format.
       fs.writeFileSync('.versionrc', JSON.stringify({
@@ -1055,6 +1044,19 @@ describe('standard-version', function () {
       // CHANGELOG should have the new issue URL format.
       const content = fs.readFileSync('CHANGELOG.md', 'utf-8')
       content.should.include('http://www.foo.com/1')
+    })
+  })
+
+  describe('pre-major', () => {
+    it('bumps the minor rather than major, if version < 1.0.0', function () {
+      writePackageJson('0.5.0', {
+        repository: {
+          url: 'https://github.com/yargs/yargs.git'
+        }
+      })
+      commit('feat!: this is a breaking change')
+      execCli()
+      getPackageVersion().should.equal('0.6.0')
     })
   })
 })


### PR DESCRIPTION
fixes #308 

BREAKING CHANGE: we now bump the minor rather than major if version < 1.0.0