### PR TITLE
feat: validate CLI arguments using yargs.strict

### DIFF
--- a/command.js
+++ b/command.js
@@ -105,6 +105,8 @@ const yargs = require('yargs')
       return true
     }
   })
+  .strict()
+  .showHelpOnFail(false, 'Use --help for available options.')
   .alias('version', 'v')
   .alias('help', 'h')
   .example('$0', 'Update changelog and tag release')


### PR DESCRIPTION
```
$ standard-version --dryrun
Unknown argument: dryrun

Use --help for available options.
```

resolves #367