### PR TITLE
fix(cli): Display only one, correct default for --preset flag

### DIFF
--- a/command.js
+++ b/command.js
@@ -94,7 +94,7 @@ const yargs = require('yargs')
   .option('preset', {
     type: 'string',
     default: defaults.preset,
-    describe: 'Commit message guideline preset (default: angular)'
+    describe: 'Commit message guideline preset'
   })
   .check((argv) => {
     if (typeof argv.scripts !== 'object' || Array.isArray(argv.scripts)) {


### PR DESCRIPTION
Previously `--help` would print both "angular" and "conventionalcommits" as defaults for `--preset`, which was confusing.

`$ standard-version --help`
Before:
```
  --preset             Commit message guideline preset (default: angular)
                                                        [string] [default:"conventionalcommits"]
```

After:
```
  --preset             Commit message guideline preset  [string] [default: "conventionalcommits"]
```
