### PR TITLE
 feat(configuration): .versionrc.js files are now supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,12 @@ You can configure `standard-version` either by:
 
 1. Placing a `standard-version` stanza in your `package.json` (assuming
    your project is JavaScript).
-1. Creating a `.versionrc` or `.versionrc.json`.
+2. Creating a `.versionrc`, `.versionrc.json` or `.versionrc.js`.
+  - If you are using a `.versionrc.js` your default export must be a configuration object, or a function returning a configuration object.
 
-Any of the command line paramters accepted by `standard-version` can instead
+Any of the command line parameters accepted by `standard-version` can instead
 be provided via configuration. Please refer to the [conventional-changelog-config-spec](https://github.com/conventional-changelog/conventional-changelog-config-spec/) for details on available configuration options.
+
 
 ### Customizing CHANGELOG Generation
 

--- a/command.js
+++ b/command.js
@@ -1,10 +1,6 @@
-const findUp = require('find-up')
-const defaults = require('./defaults')
-const { readFileSync } = require('fs')
-
-const configPath = findUp.sync(['.versionrc', '.versionrc.json'])
-const config = configPath ? JSON.parse(readFileSync(configPath)) : {}
 const spec = require('conventional-changelog-config-spec')
+const { getConfiguration } = require('./lib/configuration')
+const defaults = require('./defaults')
 const { START_OF_LAST_RELEASE_PATTERN } = require('./lib/lifecycles/changelog')
 
 const yargs = require('yargs')
@@ -110,7 +106,7 @@ const yargs = require('yargs')
   .example('$0', 'Update changelog and tag release')
   .example('$0 -m "%s: see changelog for details"', 'Update changelog and tag release with custom commit message')
   .pkgConf('standard-version')
-  .config(config)
+  .config(getConfiguration())
   .wrap(97)
   .check((args) => {
     if (args.changelogHeader && args.changelogHeader.search(START_OF_LAST_RELEASE_PATTERN) !== -1) {

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -1,0 +1,40 @@
+const path = require('path')
+const findUp = require('find-up')
+const { readFileSync } = require('fs')
+
+const CONFIGURATION_FILES = [
+  '.versionrc',
+  '.versionrc.json',
+  '.versionrc.js'
+]
+
+module.exports.getConfiguration = function () {
+  let config = {}
+  const configPath = findUp.sync(CONFIGURATION_FILES)
+  if (!configPath) {
+    return config
+  }
+  if (path.extname(configPath) === '.js') {
+    const jsConfiguration = require(configPath)
+    if (typeof jsConfiguration === 'function') {
+      config = jsConfiguration()
+    } else {
+      config = jsConfiguration
+    }
+  } else {
+    config = JSON.parse(readFileSync(configPath))
+  }
+
+  /**
+   * @todo we could eventually have deeper validation of the configuration (using `ajv`) and
+   * provide a more helpful error.
+   */
+  if (typeof config !== 'object') {
+    throw Error(
+      '[standard-version] Invalid default export found in configuration file.\n' +
+      'You must provide an object or function.'
+    )
+  }
+
+  return config
+}

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -31,8 +31,7 @@ module.exports.getConfiguration = function () {
    */
   if (typeof config !== 'object') {
     throw Error(
-      '[standard-version] Invalid default export found in configuration file.\n' +
-      'You must provide an object or function.'
+      `[standard-version] Invalid configuration in ${configPath} provided. Expected an object but found ${typeof config}.`
     )
   }
 

--- a/test.js
+++ b/test.js
@@ -1099,6 +1099,54 @@ describe('standard-version', function () {
       content.should.include('http://www.foo.com/1')
     })
 
+    it('evaluates a config-function from .versionrc.js', function () {
+      // write configuration that overrides default issue
+      // URL format.
+      fs.writeFileSync(
+        '.versionrc.js',
+        `module.exports = function() {
+          return {
+            issueUrlFormat: 'http://www.versionrc.js/function/{{id}}'
+          }
+        }`,
+        'utf-8'
+      )
+      commit('feat: another commit addresses issue #1')
+      execCli()
+      // CHANGELOG should have the new issue URL format.
+      const content = fs.readFileSync('CHANGELOG.md', 'utf-8')
+      content.should.include('http://www.versionrc.js/function/1')
+    })
+
+    it('evaluates a config-object from .versionrc.js', function () {
+      // write configuration that overrides default issue
+      // URL format.
+      fs.writeFileSync(
+        '.versionrc.js',
+        `module.exports = {
+          issueUrlFormat: 'http://www.versionrc.js/object/{{id}}'
+        }`,
+        'utf-8'
+      )
+      commit('feat: another commit addresses issue #1')
+      execCli()
+      // CHANGELOG should have the new issue URL format.
+      const content = fs.readFileSync('CHANGELOG.md', 'utf-8')
+      content.should.include('http://www.versionrc.js/object/1')
+    })
+
+    it('throws an error when a non-object is returned from .versionrc.js', function () {
+      // write configuration that overrides default issue
+      // URL format.
+      fs.writeFileSync(
+        '.versionrc.js',
+        `module.exports = 3`,
+        'utf-8'
+      )
+      commit('feat: another commit addresses issue #1')
+      execCli().code.should.equal(1)
+    })
+
     it('.versionrc : releaseCommitMessageFormat', function () {
       // write configuration that overrides default issue
       // URL format.


### PR DESCRIPTION
- Updates the configuration retrieval to support Javascript (`.js`) configurations.
- Javascript configurations MUST export a configuration object _or_ a function (returning a configuration object) as the default export.
- Adds details around `.versionrc.js` to README.

closes #371