### PR TITLE
fix: Updates package.json to _actual_ supported (tested) NodeJS versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "git+https://github.com/conventional-changelog/standard-version.git"
   },
   "engines": {
-    "node": ">=4.0"
+    "node": ">=8.0"
   },
   "keywords": [
     "conventional-changelog",


### PR DESCRIPTION
- 6 support was dropped in May (671842853b9fa62ecda126bf5e1fbe7aa60a5d1f), 4 and 5 were dropped in November 2018 (1d466275518ae2649758b9e0e9b3c848734f534f)

We should be able to close out (#286) once this is merged. It's the only changed [that was mentioned](https://github.com/conventional-changelog/standard-version/issues/286#issuecomment-446550907) that hasn't made it into a tagged version. 