### PR TITLE
docs(cli): note about yargs dot notation in lieu of package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Making these URLs match GitLab's format, rather than GitHub's.
 
 ## CLI Usage
 
-> NOTE: To pass nested configurations to the CLI without defining them in the `package.json` use [yargs dot notation](http://adilapapaya.com/docs/yargs/#dotnotation).
+> **NOTE:** To pass nested configurations to the CLI without defining them in the `package.json` use dot notation as the parameters `e.g. --skip.changelog`.
 
 ### First Release
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Making these URLs match GitLab's format, rather than GitHub's.
 
 ## CLI Usage
 
+> NOTE: To pass nested configurations to the CLI without defining them in the `package.json` use [yargs dot notation](http://adilapapaya.com/docs/yargs/#dotnotation).
+
 ### First Release
 
 To generate your changelog for your first release, simply do:


### PR DESCRIPTION
To help simpletons such as myself understand how yargs work (see #373)