### PR TITLE
fix(bump): transmit tag prefix argument to conventionalRecommendedBump

### DIFF
--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -143,7 +143,8 @@ function bumpVersion (releaseAs, currentVersion, args) {
       conventionalRecommendedBump({
         debug: args.verbose && console.info.bind(console, 'conventional-recommended-bump'),
         preset: presetOptions,
-        path: args.path
+        path: args.path,
+        tagPrefix: args.tagPrefix
       }, function (err, release) {
         if (err) return reject(err)
         else return resolve(release)


### PR DESCRIPTION
The `prefixTag` is never transmitted to `conventionalRecommendedBump` parameters.
In my case, I have a monorepo with several prefixed tags and `standard-version` would always bump to major because of using wrong "from" tag.
