### PR TITLE
docs: add link to configuration spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can configure `standard-version` either by:
 1. Creating a `.versionrc` or `.versionrc.json`.
 
 Any of the command line paramters accepted by `standard-version` can instead
-be provided via configuration.
+be provided via configuration. Please refer to the [conventional-changelog-config-spec](https://github.com/conventional-changelog/conventional-changelog-config-spec/) for details on available configuration options.
 
 ### Customizing CHANGELOG Generation
 


### PR DESCRIPTION
I had no idea what to put in the `.versionrc` until i stumbled upon the spec. A sample for how to do it in the `package.json` would be a great resource also but I don't know how to do that from reading the docs.

It is still unclear to me if it is only cli options are available or if the options in link I provided also work.