### PR TITLE
deps: bumps conventional-changelog to 3.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/conventional-changelog/standard-version#readme",
   "dependencies": {
     "chalk": "2.4.2",
-    "conventional-changelog": "3.1.8",
+    "conventional-changelog": "3.1.9",
     "conventional-changelog-config-spec": "2.0.0",
     "conventional-recommended-bump": "5.0.0",
     "detect-indent": "6.0.0",

--- a/test.js
+++ b/test.js
@@ -207,7 +207,7 @@ describe('cli', function () {
       execCli(cliArgs).code.should.equal(0)
       content = fs.readFileSync('CHANGELOG.md', 'utf-8')
       content = content.replace(/patch release [0-9a-f]{6,8}/g, 'patch release ABCDEFXY').replace(/\([0-9]{4}-[0-9]{2}-[0-9]{2}\)/g, '(YYYY-MM-DD)')
-      content.should.equal('# Changelog\n\nAll notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.\n\n### [1.0.2](/compare/v1.0.1...v1.0.2) (YYYY-MM-DD)\n\n\n### Bug Fixes\n\n* another patch release ABCDEFXY\n\n\n\n### [1.0.1](/compare/v1.0.0...v1.0.1) (YYYY-MM-DD)\n\n\n### Bug Fixes\n\n* patch release ABCDEFXY\n')
+      content.should.equal('# Changelog\n\nAll notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.\n\n### [1.0.2](/compare/v1.0.1...v1.0.2) (YYYY-MM-DD)\n\n\n### Bug Fixes\n\n* another patch release ABCDEFXY\n\n### [1.0.1](/compare/v1.0.0...v1.0.1) (YYYY-MM-DD)\n\n\n### Bug Fixes\n\n* patch release ABCDEFXY\n')
     })
 
     it('commits all staged files', function () {


### PR DESCRIPTION
- This will bump the transitive dependencies found in conventional-changelog which should ensure we're keeping in-sync with the features and fixes being applied to presets.
- This *did* require a change to a test case's expected output (-2 new-lines)... I don't think this needs to be seen as breaking and my assumption is it was just caused by some tweaks to templates in the conventional-changelog-conventionalcommits preset.