### PR TITLE
chore(deps,conventional-changelog): Bumps conventional-changelog to 3.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/conventional-changelog/standard-version#readme",
   "dependencies": {
     "chalk": "2.4.2",
-    "conventional-changelog": "3.1.9",
+    "conventional-changelog": "3.1.10",
     "conventional-changelog-config-spec": "2.0.0",
     "conventional-recommended-bump": "6.0.0",
     "detect-indent": "6.0.0",


### PR DESCRIPTION
- This is expected to resolve #410 based on updates in the conventional-commits preset.