### PR TITLE
Detect if release is necessary

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,15 @@ const latestSemverTag = require('./lib/latest-semver-tag')
 const path = require('path')
 const printError = require('./lib/print-error')
 const tag = require('./lib/lifecycles/tag')
+const commits = require('./lib/commits');
+
+(async function () {
+  const commitsSinceLastTag = await commits()
+  console.log(commitsSinceLastTag)
+
+  // TODO: Update logic to handle bump based on commit messages
+  // TODO: integrate with the normal standard-version API (do we add a flag? or break current API & Tests as suggested in thread??)
+})()
 
 module.exports = function standardVersion (argv) {
   /**

--- a/lib/commits.js
+++ b/lib/commits.js
@@ -1,0 +1,29 @@
+const gitLogParser = require('git-log-parser')
+const getStream = require('get-stream')
+
+/**
+ * Returns the list of commits since that last commit that had a tag or all of them
+ */
+module.exports = async () => {
+  Object.assign(gitLogParser.fields, {
+    hash: 'H',
+    message: 'B',
+    gitTags: 'd',
+    committerDate: { key: 'ci', type: Date }
+  })
+  const commits = (await getStream.array(
+    gitLogParser.parse(
+      { _: 'HEAD' }
+    )
+  )).map(commit => {
+    commit.message = commit.message.trim()
+    commit.gitTags = commit.gitTags.trim()
+    return commit
+  });
+
+  const endCommitIndex = commits.findIndex(c => c.gitTags && c.gitTags.length && c.gitTags.includes('tag:'))
+  const commitsSinceLastTag = endCommitIndex === -1 ? commits : commits.slice(0, endCommitIndex)
+
+  console.log(`Found ${commitsSinceLastTag.length} commits since last release`)
+  return commitsSinceLastTag
+}

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "figures": "3.0.0",
     "find-up": "4.1.0",
     "fs-access": "1.0.1",
+    "git-log-parser": "1.2.0",
     "git-semver-tags": "3.0.0",
     "semver": "6.3.0",
     "stringify-package": "1.0.0",


### PR DESCRIPTION
Relates to https://github.com/conventional-changelog/standard-version/issues/192

WIP

Current implementation is only a prof of concept as I didn't had any more to time to finish it, however I'd still like to discuss it as someone can easily pick up were I left of.

Mostly I want to discuss the way in which this is going to be integrated in the lib as if we do it as suggested in the issue above it is a breaking change and will almost break all the tests on the repo.

That's a ton of work to add this feature which is why it might be too daunting to do so.

Either way once August passes by and I get a bit more free time i would like to get this done, so for now I just want to discuss the approach to implement it.