### PR TITLE
feat: add ability to supply a version to bump from

### DIFF
--- a/command.js
+++ b/command.js
@@ -16,6 +16,11 @@ const yargs = require('yargs')
     describe: 'make a pre-release with optional option value to specify a tag id',
     string: true
   })
+  .option('use-current-version', {
+    describe: 'Specify the current version to bump',
+    requiresArg: true,
+    string: true
+  })
   .option('infile', {
     alias: 'i',
     describe: 'Read the CHANGELOG from this file',

--- a/index.js
+++ b/index.js
@@ -39,7 +39,9 @@ module.exports = function standardVersion (argv) {
 
   return Promise.resolve()
     .then(() => {
-      if (!pkg && args.gitTagFallback) {
+      if (args.useCurrentVersion) {
+        return args.useCurrentVersion
+      } else if (!pkg && args.gitTagFallback) {
         return latestSemverTag()
       } else if (!pkg) {
         throw new Error('no package file found')


### PR DESCRIPTION
In some instances we may want to supply our own version to bump from, i.e. supply from a git tag or some other arbitrary source.