### PR TITLE
feat(Updaters, bumpFiles, packageFiles): Adds `regex` built-in updater.

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = function standardVersion (argv) {
     try {
       let contents = fs.readFileSync(pkgPath, 'utf8')
       pkg = {
-        version: updater.updater.readVersion(contents),
+        version: updater.updater.readVersion(contents, updater.options),
         private: typeof updater.updater.isPrivate === 'function' ? updater.updater.isPrivate(contents) : false
       }
     } catch (err) {}

--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -161,12 +161,12 @@ function updateConfigs (args, newVersion) {
       checkpoint(
         args,
         'bumping version in ' + updater.filename + ' from %s to %s',
-        [updater.updater.readVersion(contents), newVersion]
+        [updater.updater.readVersion(contents, updater.options), newVersion]
       )
       writeFile(
         args,
         configPath,
-        updater.updater.writeVersion(contents, newVersion)
+        updater.updater.writeVersion(contents, newVersion, updater.options)
       )
       // flag any config files that we modify the version # for
       // as having been updated.

--- a/lib/updaters/index.js
+++ b/lib/updaters/index.js
@@ -34,7 +34,8 @@ module.exports.resolveUpdaterObjectFromArgument = function (arg) {
   let updater = arg
   if (typeof updater !== 'object') {
     updater = {
-      filename: arg
+      filename: arg,
+      options: {}
     }
   }
   try {

--- a/lib/updaters/types/regex.js
+++ b/lib/updaters/types/regex.js
@@ -1,0 +1,28 @@
+module.exports.readVersion = function (contents, options) {
+  let match = options.match
+  if (!match) {
+    throw Error('You must provide a `match` option when using the `regex` updater.')
+  }
+  const found = contents.match(match)
+  if (!found) {
+    throw Error('No matches found for provided `match`.')
+  }
+  if (!found.groups || !found.groups.version) {
+    throw Error('The named capture group `version` was not found.')
+  }
+  return found.groups.version
+}
+
+module.exports.writeVersion = function (contents, version, options) {
+  let replace = options.replace
+  if (!replace) {
+    throw Error('You must provide a `replace` option when using the `regex` updater.')
+  }
+  if (replace instanceof RegExp) {
+    replace = [replace]
+  }
+  replace.forEach((r) => {
+    contents = contents.replace(r, version)
+  })
+  return contents
+}

--- a/test.js
+++ b/test.js
@@ -963,6 +963,73 @@ describe('standard-version', function () {
           fs.readFileSync('VERSION_TRACKER.txt', 'utf-8').should.equal('1.1.0')
         })
     })
+
+    it('bumps a custom `regex` file', function () {
+      fs.copyFileSync('../test/mocks/release.bundle', 'release.bundle')
+      commit('feat: first commit')
+      return require('./index')({
+        silent: true,
+        packageFiles: [
+          {
+            filename: 'release.bundle',
+            type: 'regex',
+            options: {
+              match: /version = '(?<version>.*)'/
+            }
+          }
+        ],
+        bumpFiles: [
+          {
+            filename: 'release.bundle',
+            type: 'regex',
+            options: {
+              match: /version = '(?<version>.*)'/,
+              replace: [
+                /(?<=version = ').*(?=')/
+              ]
+            }
+          }
+        ]
+      })
+        .then(() => {
+          fs.readFileSync('release.bundle', 'utf-8').should.contain(`version = '0.0.2'`)
+        })
+    })
+
+    it('bumps a custom `regex` file with multiple `replace`', function () {
+      fs.copyFileSync('../test/mocks/VERSION-METADATA.txt', 'VERSION-METADATA.txt')
+      commit('feat: first commit')
+      return require('./index')({
+        silent: true,
+        packageFiles: [
+          {
+            filename: 'VERSION-METADATA.txt',
+            type: 'regex',
+            options: {
+              match: /version = '(?<version>.*)'/
+            }
+          }
+        ],
+        bumpFiles: [
+          {
+            filename: 'VERSION-METADATA.txt',
+            type: 'regex',
+            options: {
+              match: /version = '(?<version>.*)'/,
+              replace: [
+                /(?<=version = ').*(?=')/,
+                /(?<=standard-version@).*(?=')/g
+              ]
+            }
+          }
+        ]
+      })
+        .then(() => {
+          fs.readFileSync('VERSION-METADATA.txt', 'utf-8')
+            .should
+            .eq(`name = 'standard-version@0.0.2'\nversion = '0.0.2'\ntags = ['standard-version@0.0.2']`)
+        })
+    })
   })
 
   describe('custom `packageFiles` support', function () {

--- a/test/mocks/VERSION-METADATA.txt
+++ b/test/mocks/VERSION-METADATA.txt
@@ -1,0 +1,3 @@
+name = 'standard-version@0.0.1'
+version = '0.0.1'
+tags = ['standard-version@0.0.1']

--- a/test/mocks/release.bundle
+++ b/test/mocks/release.bundle
@@ -1,0 +1,4 @@
+name = 'release.bundle'
+author = 'conventional-changelog'
+version = '0.0.1'
+metadata = ['standard-version']


### PR DESCRIPTION
- Adds a built-in updater for `regex`
- Allows passing of `options` to updaters (`readVersion` and `writeVersion` methods)

---

This updater was added based on [feedback provided](https://github.com/conventional-changelog/standard-version/pull/372#issuecomment-527881781) in #372

