### PR TITLE
fix: enforce require.resolve for the default preset

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -12,7 +12,7 @@ const defaults = {
   skip: {},
   dryRun: false,
   gitTagFallback: true,
-  preset: 'conventionalcommits'
+  preset: require.resolve('conventional-changelog-conventionalcommits')
 }
 
 /**

--- a/lib/preset-loader.js
+++ b/lib/preset-loader.js
@@ -3,10 +3,11 @@
 const spec = require('conventional-changelog-config-spec')
 
 module.exports = (args) => {
-  let preset = args.preset || 'conventionalcommits'
-  if (preset === 'conventionalcommits') {
+  const defaultPreset = require.resolve('conventional-changelog-conventionalcommits')
+  let preset = args.preset || defaultPreset
+  if (preset === defaultPreset) {
     preset = {
-      name: preset
+      name: defaultPreset
     }
     Object.keys(spec.properties).forEach(key => {
       if (args[key] !== undefined) preset[key] = args[key]

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "chalk": "2.4.2",
     "conventional-changelog": "3.1.15",
     "conventional-changelog-config-spec": "2.1.0",
-    "conventional-changelog-conventionalcommits": "^4.2.1",
+    "conventional-changelog-conventionalcommits": "4.2.1",
     "conventional-recommended-bump": "6.0.5",
     "detect-indent": "6.0.0",
     "detect-newline": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "chalk": "2.4.2",
     "conventional-changelog": "3.1.15",
     "conventional-changelog-config-spec": "2.1.0",
+    "conventional-changelog-conventionalcommits": "^4.2.1",
     "conventional-recommended-bump": "6.0.5",
     "detect-indent": "6.0.0",
     "detect-newline": "3.0.0",


### PR DESCRIPTION
In order to support Yarn 2/PnP, `conventional-changelog-conventionalcommits` must be declared in package.json and referenced using `require.resolve`.

Requires https://github.com/conventional-changelog/conventional-changelog/pull/530