### PR TITLE
No need to bumb version in composer.lock and composer.json

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -32,14 +32,12 @@ defaults.header = '# Changelog\n\nAll notable changes to this project will be do
 defaults.packageFiles = [
   'package.json',
   'bower.json',
-  'manifest.json',
-  'composer.json'
+  'manifest.json'
 ]
 
 defaults.bumpFiles = defaults.packageFiles.concat([
   'package-lock.json',
-  'npm-shrinkwrap.json',
-  'composer.lock'
+  'npm-shrinkwrap.json'
 ])
 
 module.exports = defaults


### PR DESCRIPTION
closes #394

[Composer docs](https://getcomposer.org/doc/04-schema.md#version) states that version in composer.json is

> Optional if the package repository can infer the version from somewhere, such as the VCS tag name in the VCS repository. In that case it is also recommended to omit it.