### PR TITLE
Fix incorrect key name in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,17 +365,17 @@ YES! Using `bumpFiles` (and `packageFiles`) configurations you should be able to
 {
   "bumpFiles": [
     {
-      "file": "MY_VERSION_TRACKER.txt",
+      "filename": "MY_VERSION_TRACKER.txt",
       // The `plain-text` updater assumes the file contents represents the version.
       "type": "plain-text"
     },
     {
-      "file": "a/deep/package/dot/json/file/package.json",
+      "filename": "a/deep/package/dot/json/file/package.json",
       // The `json` updater assumes the version is available under a `version` key in the provided JSON document.
       "type": "json"
-    }
+    },
     {
-      "file": "VERSION_TRACKER.json",
+      "filename": "VERSION_TRACKER.json",
       //  See "Custom `updater`s" for more details.
       "updater": "standard-version-updater.js"
     }


### PR DESCRIPTION
I've spent quite some time trying to figure out why my custom config didn't work out and I wanted to give up on the project but then I decided to take a look under the hood and found out there is incorrect information in `README.md` docs. So this PR fixes the wrong key name in JSON config.