### PR TITLE
docs: `packageFiles` is used to get version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _How It Works:_
 
 `standard-version` will then do the following:
 
-1. Retrieve the current version of your repository by looking at `bumpFiles`[[1]](#bumpfiles-packagefiles-and-updaters), falling back to the last `git tag`.
+1. Retrieve the current version of your repository by looking at `packageFiles`[[1]](#bumpfiles-packagefiles-and-updaters), falling back to the last `git tag`.
 2. `bump` the version in `bumpFiles`[[1]](#bumpfiles-packagefiles-and-updaters) based on your commits.
 4. Generates a `changelog` based on your commits (uses [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) under the hood).
 5. Creates a new `commit` including your `bumpFiles`[[1]](#bumpfiles-packagefiles-and-updaters) and updated CHANGELOG.


### PR DESCRIPTION
The readme states that `bumpFiles` is used to retrieve the current version, but it's actually `packageFiles`

https://github.com/conventional-changelog/standard-version/blob/2f04ac8fc1c134a1981c23a093d4eece77d0bbb9/index.js#L41-L43