### PR TITLE
feat(changelog): allow to pass a custom context

### DIFF
--- a/command.js
+++ b/command.js
@@ -4,6 +4,10 @@ const defaults = require('./defaults')
 
 const yargs = require('yargs')
   .usage('Usage: $0 [options]')
+  .option('context', {
+    type: 'string',
+    describe: 'Pass a custom context to inject during the changelog generation'
+  })
   .option('packageFiles', {
     default: defaults.packageFiles,
     array: true
@@ -20,7 +24,7 @@ const yargs = require('yargs')
   })
   .option('prerelease', {
     alias: 'p',
-    describe: 'make a pre-release with optional option value to specify a tag id',
+    describe: 'Make a pre-release with optional option value to specify a tag id',
     string: true
   })
   .option('infile', {

--- a/index.js
+++ b/index.js
@@ -26,6 +26,16 @@ module.exports = function standardVersion (argv) {
     }
   }
 
+  if (argv.context) {
+    if (typeof argv.context === 'string') {
+      try {
+        argv.context = JSON.parse(argv.context)
+      } catch (error) {
+        throw new Error(`Error while parsing context: ${error.message}`)
+      }
+    }
+  }
+
   if (argv.changelogHeader) {
     argv.header = argv.changelogHeader
     if (!argv.silent) {

--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -35,7 +35,8 @@ function outputChangelog (args, newVersion) {
       oldContent = oldContent.substring(oldContentStart)
     }
     let content = ''
-    const context = { version: newVersion }
+    const customContext = args.context || {}
+    const context = { ...customContext, version: newVersion }
     const changelogStream = conventionalChangelog({
       debug: args.verbose && console.info.bind(console, 'conventional-changelog'),
       preset: presetLoader(args),

--- a/test.js
+++ b/test.js
@@ -124,6 +124,22 @@ describe('cli', function () {
   beforeEach(initInTempFolder)
   afterEach(finishTemp)
 
+  it('should take a context', function () {
+    commit('feat: first commit')
+    shell.exec('git tag -a v1.0.0 -m "my awesome first release"')
+    commit('fix: patch release')
+    execCli('--context \'{ "owner": "owner", "repository": "repository" }\'').code.should.equal(0)
+    const changelog = fs.readFileSync('CHANGELOG.md', 'utf8')
+    changelog.should.include('[1.0.1](/owner/repository/compare/v1.0.0...v1.0.1)')
+  })
+
+  it('should error on invalid context', function () {
+    commit('feat: first commit')
+    shell.exec('git tag -a v1.0.0 -m "my awesome first release"')
+    commit('fix: patch release')
+    execCli('--context \'{ "owner": "owner", "repository":  }\'').code.should.equal(1)
+  })
+
   describe('CHANGELOG.md does not exist', function () {
     it('populates changelog with commits since last tag by default', function () {
       commit('feat: first commit')
@@ -858,6 +874,20 @@ describe('standard-version', function () {
           return done()
         })
     })
+  })
+
+  it('should pass a custom context', function (done) {
+    commit('feat: first commit')
+    shell.exec('git tag -a v1.0.0 -m "my awesome first release"')
+    commit('feat: new feature!')
+    require('./index')({
+      silent: true,
+      context: { owner: 'owner', repository: 'respository' }
+    }).then(() => {
+      const changelog = fs.readFileSync('CHANGELOG.md', 'utf8')
+      changelog.should.include('[1.1.0](/owner/respository/compare/v1.0.0...v1.1.0)')
+      done()
+    }).catch(done)
   })
 
   it('formats the commit and tag messages appropriately', function (done) {


### PR DESCRIPTION
In repositories that are self-hosted most of the time the changelog is genereated with broken links that are missing the owner and the repository in the path.
Allowing to pass a custom context to conventionalChangelog mitigates this.

See issue #525 and #227.

`.versionrc.js` example configuration
```js
module.exports = {
//...
context: {
  owner: 'some repo owner',
  repository: 'foo'
}
```


---

I saw #174 after opening this, sorry.