### PR TITLE
chore: Allow semver ranges for non-devDependencies – renovate-bot should no longer force the change.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "detect-indent": "6.0.0",
     "detect-newline": "3.1.0",
     "dotgitignore": "2.1.0",
-    "figures": "3.1.0",
+    "figures": "^3.1.0",
     "find-up": "4.1.0",
     "fs-access": "1.0.1",
     "git-semver-tags": "3.0.1",

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "extends": [
-    "config:base"
+    "config:js-lib"
   ]
 }


### PR DESCRIPTION
Updates Renovate configuration to use "config:js-lib" (https://docs.renovatebot.com/presets-config/#configjs-lib), this introduces the ":pinOnlyDevDependencies" configuration.

see: #590