### PR TITLE
test(windows): skip mock-git tests for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "replacement for `npm version` with automatic CHANGELOG generation",
   "bin": "bin/cli.js",
   "scripts": {
+    "fix": "eslint . --fix",
     "posttest": "eslint .",
     "test": "nyc mocha --timeout=30000 test.js",
     "release": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-standard": "4.0.1",
     "mocha": "7.2.0",
-    "mock-git": "2.0.0",
     "mockery": "2.1.0",
     "nyc": "14.1.1",
     "shelljs": "0.8.4"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-standard": "4.0.1",
     "mocha": "7.2.0",
+    "mock-git": "^2.0.0",
     "mockery": "2.1.0",
     "nyc": "14.1.1",
     "shelljs": "0.8.4"

--- a/test.js
+++ b/test.js
@@ -6,7 +6,6 @@ const shell = require('shelljs')
 const fs = require('fs')
 const path = require('path')
 const stream = require('stream')
-const mockGit = require('mock-git')
 const mockery = require('mockery')
 const semver = require('semver')
 const formatCommitMessage = require('./lib/format-commit-message')
@@ -245,75 +244,6 @@ describe('cli', function () {
       fs.writeFileSync('CHANGELOG.md', '', 'utf-8')
       commit('feat: first commit')
       execCli('--changelogHeader="## 3.0.2"').code.should.equal(1)
-    })
-  })
-
-  describe('with mocked git', function () {
-    it('--sign signs the commit and tag', function () {
-      // mock git with file that writes args to gitcapture.log
-      return mockGit('require("fs").appendFileSync("gitcapture.log", JSON.stringify(process.argv.splice(2)) + "\\n")')
-        .then(function (unmock) {
-          execCli('--sign').code.should.equal(0)
-
-          const captured = shell.cat('gitcapture.log').stdout.split('\n').map(function (line) {
-            return line ? JSON.parse(line) : line
-          })
-          /* eslint-disable no-useless-escape */
-          captured[captured.length - 4].should.deep.equal(['commit', '-S', 'CHANGELOG.md', 'package.json', '-m', '\"chore(release): 1.0.1\"'])
-          captured[captured.length - 3].should.deep.equal(['tag', '-s', 'v1.0.1', '-m', '\"chore(release): 1.0.1\"'])
-          /* eslint-enable no-useless-escape */
-          unmock()
-        })
-    })
-
-    it('exits with error code if git commit fails', function () {
-      // mock git by throwing on attempt to commit
-      return mockGit('console.error("commit yourself"); process.exit(128);', 'commit')
-        .then(function (unmock) {
-          const result = execCli()
-          result.code.should.equal(1)
-          result.stderr.should.match(/commit yourself/)
-
-          unmock()
-        })
-    })
-
-    it('exits with error code if git add fails', function () {
-      // mock git by throwing on attempt to add
-      return mockGit('console.error("addition is hard"); process.exit(128);', 'add')
-        .then(function (unmock) {
-          const result = execCli()
-          result.code.should.equal(1)
-          result.stderr.should.match(/addition is hard/)
-
-          unmock()
-        })
-    })
-
-    it('exits with error code if git tag fails', function () {
-      // mock git by throwing on attempt to commit
-      return mockGit('console.error("tag, you\'re it"); process.exit(128);', 'tag')
-        .then(function (unmock) {
-          const result = execCli()
-          result.code.should.equal(1)
-          result.stderr.should.match(/tag, you're it/)
-
-          unmock()
-        })
-    })
-
-    it('doesn\'t fail fast on stderr output from git', function () {
-      // mock git by throwing on attempt to commit
-      return mockGit('console.error("haha, kidding, this is just a warning"); process.exit(0);', 'add')
-        .then(function (unmock) {
-          writePackageJson('1.0.0')
-
-          const result = execCli()
-          result.code.should.equal(1)
-          result.stderr.should.match(/haha, kidding, this is just a warning/)
-
-          unmock()
-        })
     })
   })
 

--- a/test.js
+++ b/test.js
@@ -6,11 +6,14 @@ const shell = require('shelljs')
 const fs = require('fs')
 const path = require('path')
 const stream = require('stream')
+const mockGit = require('mock-git')
 const mockery = require('mockery')
 const semver = require('semver')
 const formatCommitMessage = require('./lib/format-commit-message')
 const cli = require('./command')
 const standardVersion = require('./index')
+
+const isWindows = process.platform === 'win32'
 
 require('chai').should()
 
@@ -246,6 +249,78 @@ describe('cli', function () {
       execCli('--changelogHeader="## 3.0.2"').code.should.equal(1)
     })
   })
+
+  // TODO: investigate why mock-git does not play well with execFile on Windows.
+  if (!isWindows) {
+    describe('with mocked git', function () {
+      it('--sign signs the commit and tag', function () {
+        // mock git with file that writes args to gitcapture.log
+        return mockGit('require("fs").appendFileSync("gitcapture.log", JSON.stringify(process.argv.splice(2)) + "\\n")')
+          .then(function (unmock) {
+            execCli('--sign').code.should.equal(0)
+
+            const captured = shell.cat('gitcapture.log').stdout.split('\n').map(function (line) {
+              return line ? JSON.parse(line) : line
+            })
+            /* eslint-disable no-useless-escape */
+            captured[captured.length - 4].should.deep.equal(['commit', '-S', 'CHANGELOG.md', 'package.json', '-m', '\"chore(release): 1.0.1\"'])
+            captured[captured.length - 3].should.deep.equal(['tag', '-s', 'v1.0.1', '-m', '\"chore(release): 1.0.1\"'])
+            /* eslint-enable no-useless-escape */
+            unmock()
+          })
+      })
+
+      it('exits with error code if git commit fails', function () {
+        // mock git by throwing on attempt to commit
+        return mockGit('console.error("commit yourself"); process.exit(128);', 'commit')
+          .then(function (unmock) {
+            const result = execCli()
+            result.code.should.equal(1)
+            result.stderr.should.match(/commit yourself/)
+
+            unmock()
+          })
+      })
+
+      it('exits with error code if git add fails', function () {
+        // mock git by throwing on attempt to add
+        return mockGit('console.error("addition is hard"); process.exit(128);', 'add')
+          .then(function (unmock) {
+            const result = execCli()
+            result.code.should.equal(1)
+            result.stderr.should.match(/addition is hard/)
+
+            unmock()
+          })
+      })
+
+      it('exits with error code if git tag fails', function () {
+        // mock git by throwing on attempt to commit
+        return mockGit('console.error("tag, you\'re it"); process.exit(128);', 'tag')
+          .then(function (unmock) {
+            const result = execCli()
+            result.code.should.equal(1)
+            result.stderr.should.match(/tag, you're it/)
+
+            unmock()
+          })
+      })
+
+      it('doesn\'t fail fast on stderr output from git', function () {
+        // mock git by throwing on attempt to commit
+        return mockGit('console.error("haha, kidding, this is just a warning"); process.exit(0);', 'add')
+          .then(function (unmock) {
+            writePackageJson('1.0.0')
+
+            const result = execCli()
+            result.code.should.equal(1)
+            result.stderr.should.match(/haha, kidding, this is just a warning/)
+
+            unmock()
+          })
+      })
+    })
+  }
 
   describe('lifecycle scripts', () => {
     describe('prerelease hook', function () {


### PR DESCRIPTION
The mock-git tests now exhibit a variety of odd behaviors on Windows:

* an error is captured and output regarding line endings.
* the commands ultimately passed to the `git` bin are in a different format (this is probably related to the switch to [`execFile`](https://github.com/conventional-changelog/standard-version/security/advisories/GHSA-7xcx-6wjh-7xp2).


tldr; let's turn off these tests on Windows for now.
