### PR TITLE
fix: don't enclose commit message and tag name in quotes

### DIFF
--- a/lib/lifecycles/commit.js
+++ b/lib/lifecycles/commit.js
@@ -67,7 +67,7 @@ function execCommit (args, newVersion) {
           args.commitAll ? [] : toAdd,
           [
             '-m',
-            `"${formatCommitMessage(args.releaseCommitMessageFormat, newVersion)}"`
+            `${formatCommitMessage(args.releaseCommitMessageFormat, newVersion)}`
           ]
         )
       )

--- a/lib/lifecycles/tag.js
+++ b/lib/lifecycles/tag.js
@@ -25,7 +25,7 @@ function execTag (newVersion, pkgPrivate, args) {
     tagOption = '-a'
   }
   checkpoint(args, 'tagging release %s%s', [args.tagPrefix, newVersion])
-  return runExecFile(args, 'git', ['tag', tagOption, args.tagPrefix + newVersion, '-m', `"${formatCommitMessage(args.releaseCommitMessageFormat, newVersion)}"`])
+  return runExecFile(args, 'git', ['tag', tagOption, args.tagPrefix + newVersion, '-m', `${formatCommitMessage(args.releaseCommitMessageFormat, newVersion)}`])
     .then(() => runExecFile('', 'git', ['rev-parse', '--abbrev-ref', 'HEAD']))
     .then((currentBranch) => {
       let message = 'git push --follow-tags origin ' + currentBranch.trim()

--- a/test.js
+++ b/test.js
@@ -263,7 +263,7 @@ describe('cli', function () {
               return line ? JSON.parse(line) : line
             })
             /* eslint-disable no-useless-escape */
-            captured[captured.length - 4].should.deep.equal(['commit', '-S', 'CHANGELOG.md', 'package.json', '-m', '\"chore(release): 1.0.1\"'])
+            captured[captured.length - 4].should.deep.equal(['commit', '-S', 'CHANGELOG.md', 'package.json', '-m', 'chore(release): 1.0.1'])
             captured[captured.length - 3].should.deep.equal(['tag', '-s', 'v1.0.1', '-m', '\"chore(release): 1.0.1\"'])
             /* eslint-enable no-useless-escape */
             unmock()

--- a/test.js
+++ b/test.js
@@ -264,7 +264,7 @@ describe('cli', function () {
             })
             /* eslint-disable no-useless-escape */
             captured[captured.length - 4].should.deep.equal(['commit', '-S', 'CHANGELOG.md', 'package.json', '-m', 'chore(release): 1.0.1'])
-            captured[captured.length - 3].should.deep.equal(['tag', '-s', 'v1.0.1', '-m', '\"chore(release): 1.0.1\"'])
+            captured[captured.length - 3].should.deep.equal(['tag', '-s', 'v1.0.1', '-m', 'chore(release): 1.0.1'])
             /* eslint-enable no-useless-escape */
             unmock()
           })


### PR DESCRIPTION
Remove unwanted quotes from commit message and tag name.

With current version:
<img width="292" alt="Schermata 2020-07-12 alle 18 43 26" src="https://user-images.githubusercontent.com/2026137/87251943-a660d800-c46f-11ea-81b1-6a393278ab3a.png">

Fix #620
Fix #621 
