### PR TITLE
feat: support custom updater as object as well as path

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ As of version `7.1.0` you can configure multiple `bumpFiles` and `packageFiles`.
 
 1. Specify a custom `bumpFile` "`filename`", this is the path to the file you want to "bump"
 2. Specify the `bumpFile` "`updater`", this is _how_ the file will be bumped.
-  
+
     a. If your using a common type, you can use one of  `standard-version`'s built-in `updaters` by specifying a `type`.
 
     b. If your using an less-common version file, you can create your own `updater`.
@@ -380,6 +380,21 @@ As of version `7.1.0` you can configure multiple `bumpFiles` and `packageFiles`.
       "updater": "standard-version-updater.js"
     }
   ]
+}
+```
+
+If using `.versionrc.js` as your configuration file, the `updater` may also be set as an object, rather than a path:
+
+```js
+// .versionrc.js
+const tracker = {
+  filename: 'VERSION_TRACKER.json',
+  updater: require('./path/to/custom-version-updater')
+}
+
+module.exports = {
+  bumpFiles: [tracker],
+  packageFiles: [tracker]
 }
 ```
 

--- a/lib/updaters/index.js
+++ b/lib/updaters/index.js
@@ -27,7 +27,16 @@ function getUpdaterByFilename (filename) {
 }
 
 function getCustomUpdater (updater) {
-  return require(path.resolve(process.cwd(), updater))
+  if (typeof updater === 'string') {
+    return require(path.resolve(process.cwd(), updater))
+  }
+  if (
+    typeof updater.readVersion === 'function' &&
+    typeof updater.writeVersion === 'function'
+  ) {
+    return updater
+  }
+  throw new Error('Updater must be a string path or an object with readVersion and writeVersion methods')
 }
 
 module.exports.resolveUpdaterObjectFromArgument = function (arg) {

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -544,6 +544,28 @@ describe('standard-version', function () {
       })
       fs.readFileSync('VERSION_TRACKER.txt', 'utf-8').should.equal('6.4.0')
     })
+
+    it('allows same object to be used in packageFiles and bumpFiles', async function () {
+      mock({
+        bump: 'minor',
+        fs: {
+          'VERSION_TRACKER.txt': fs.readFileSync(
+            './test/mocks/VERSION-6.3.1.txt'
+          )
+        }
+      })
+      const origWarn = console.warn
+      console.warn = () => {
+        throw new Error('console.warn should not be called')
+      }
+      const filedesc = { filename: 'VERSION_TRACKER.txt', type: 'plain-text' }
+      try {
+        await exec({ packageFiles: [filedesc], bumpFiles: [filedesc] })
+        fs.readFileSync('VERSION_TRACKER.txt', 'utf-8').should.equal('6.4.0')
+      } finally {
+        console.warn = origWarn
+      }
+    })
   })
 
   it('bumps version # in npm-shrinkwrap.json', async function () {


### PR DESCRIPTION
This adds support for defining the `updater` directly in a JS config file, rather than requiring it to be passed in as a path to be `require`d.

Fixes #631 