### PR TITLE
refactor: use async/await syntax to simplify source files

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,19 +51,17 @@ module.exports = async function standardVersion (argv) {
       break
     } catch (err) {}
   }
-  let newVersion
   try {
+    let version
     if (pkg) {
-      newVersion = pkg.version
+      version = pkg.version
     } else if (args.gitTagFallback) {
-      newVersion = await latestSemverTag()
+      version = await latestSemverTag()
     } else {
       throw new Error('no package file found')
     }
 
-    // if bump runs, it calculates the new version that we should release at.
-    const bumpVersion = await bump(args, newVersion)
-    if (bumpVersion) newVersion = bumpVersion
+    const newVersion = await bump(args, version)
     await changelog(args, newVersion)
     await commit(args, newVersion)
     await tag(newVersion, pkg ? pkg.private : false, args)

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const printError = require('./lib/print-error')
 const tag = require('./lib/lifecycles/tag')
 const { resolveUpdaterObjectFromArgument } = require('./lib/updaters')
 
-module.exports = function standardVersion (argv) {
+module.exports = async function standardVersion (argv) {
   const defaults = require('./defaults')
   /**
    * `--message` (`-m`) support will be removed in the next major version.
@@ -39,8 +39,7 @@ module.exports = function standardVersion (argv) {
 
   const args = Object.assign({}, defaults, argv)
   let pkg
-  args.packageFiles.forEach((packageFile) => {
-    if (pkg) return
+  for (const packageFile of args.packageFiles) {
     const updater = resolveUpdaterObjectFromArgument(packageFile)
     const pkgPath = path.resolve(process.cwd(), updater.filename)
     try {
@@ -49,39 +48,27 @@ module.exports = function standardVersion (argv) {
         version: updater.updater.readVersion(contents),
         private: typeof updater.updater.isPrivate === 'function' ? updater.updater.isPrivate(contents) : false
       }
+      break
     } catch (err) {}
-  })
+  }
   let newVersion
-  return Promise.resolve()
-    .then(() => {
-      if (!pkg && args.gitTagFallback) {
-        return latestSemverTag()
-      } else if (!pkg) {
-        throw new Error('no package file found')
-      } else {
-        return pkg.version
-      }
-    })
-    .then(version => {
-      newVersion = version
-    })
-    .then(() => {
-      return bump(args, newVersion)
-    })
-    .then((_newVersion) => {
-      // if bump runs, it calculaes the new version that we
-      // should release at.
-      if (_newVersion) newVersion = _newVersion
-      return changelog(args, newVersion)
-    })
-    .then(() => {
-      return commit(args, newVersion)
-    })
-    .then(() => {
-      return tag(newVersion, pkg ? pkg.private : false, args)
-    })
-    .catch((err) => {
-      printError(args, err.message)
-      throw err
-    })
+  try {
+    if (pkg) {
+      newVersion = pkg.version
+    } else if (args.gitTagFallback) {
+      newVersion = await latestSemverTag()
+    } else {
+      throw new Error('no package file found')
+    }
+
+    // if bump runs, it calculates the new version that we should release at.
+    const bumpVersion = await bump(args, newVersion)
+    if (bumpVersion) newVersion = bumpVersion
+    await changelog(args, newVersion)
+    await commit(args, newVersion)
+    await tag(newVersion, pkg ? pkg.private : false, args)
+  } catch (err) {
+    printError(args, err.message)
+    throw err
+  }
 }

--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -14,34 +14,26 @@ const writeFile = require('../write-file')
 const { resolveUpdaterObjectFromArgument } = require('../updaters')
 let configsToUpdate = {}
 
-function Bump (args, version) {
+async function Bump (args, version) {
   // reset the cache of updated config files each
   // time we perform the version bump step.
   configsToUpdate = {}
 
-  if (args.skip.bump) return Promise.resolve()
+  if (args.skip.bump) return version
   let newVersion = version
-  return runLifecycleScript(args, 'prerelease')
-    .then(runLifecycleScript.bind(this, args, 'prebump'))
-    .then((stdout) => {
-      if (stdout && stdout.trim().length) args.releaseAs = stdout.trim()
-      return bumpVersion(args.releaseAs, version, args)
-    })
-    .then((release) => {
-      if (!args.firstRelease) {
-        const releaseType = getReleaseType(args.prerelease, release.releaseType, version)
-        newVersion = semver.valid(releaseType) || semver.inc(version, releaseType, args.prerelease)
-        updateConfigs(args, newVersion)
-      } else {
-        checkpoint(args, 'skip version bump on first release', [], chalk.red(figures.cross))
-      }
-    })
-    .then(() => {
-      return runLifecycleScript(args, 'postbump')
-    })
-    .then(() => {
-      return newVersion
-    })
+  await runLifecycleScript(args, 'prerelease')
+  const stdout = await runLifecycleScript(args, 'prebump')
+  if (stdout && stdout.trim().length) args.releaseAs = stdout.trim()
+  const release = await bumpVersion(args.releaseAs, version, args)
+  if (!args.firstRelease) {
+    const releaseType = getReleaseType(args.prerelease, release.releaseType, version)
+    newVersion = semver.valid(releaseType) || semver.inc(version, releaseType, args.prerelease)
+    updateConfigs(args, newVersion)
+  } else {
+    checkpoint(args, 'skip version bump on first release', [], chalk.red(figures.cross))
+  }
+  await runLifecycleScript(args, 'postbump')
+  return newVersion
 }
 
 Bump.getUpdatedConfigs = function () {

--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -8,15 +8,11 @@ const runLifecycleScript = require('../run-lifecycle-script')
 const writeFile = require('../write-file')
 const START_OF_LAST_RELEASE_PATTERN = /(^#+ \[?[0-9]+\.[0-9]+\.[0-9]+|<a name=)/m
 
-function Changelog (args, newVersion) {
-  if (args.skip.changelog) return Promise.resolve()
-  return runLifecycleScript(args, 'prechangelog')
-    .then(() => {
-      return outputChangelog(args, newVersion)
-    })
-    .then(() => {
-      return runLifecycleScript(args, 'postchangelog')
-    })
+async function Changelog (args, newVersion) {
+  if (args.skip.changelog) return
+  await runLifecycleScript(args, 'prechangelog')
+  await outputChangelog(args, newVersion)
+  await runLifecycleScript(args, 'postchangelog')
 }
 
 Changelog.START_OF_LAST_RELEASE_PATTERN = START_OF_LAST_RELEASE_PATTERN

--- a/lib/lifecycles/commit.js
+++ b/lib/lifecycles/commit.js
@@ -5,19 +5,15 @@ const path = require('path')
 const runExecFile = require('../run-execFile')
 const runLifecycleScript = require('../run-lifecycle-script')
 
-module.exports = function (args, newVersion) {
-  if (args.skip.commit) return Promise.resolve()
-  return runLifecycleScript(args, 'precommit')
-    .then((message) => {
-      if (message && message.length) args.releaseCommitMessageFormat = message
-      return execCommit(args, newVersion)
-    })
-    .then(() => {
-      return runLifecycleScript(args, 'postcommit')
-    })
+module.exports = async function (args, newVersion) {
+  if (args.skip.commit) return
+  const message = await runLifecycleScript(args, 'precommit')
+  if (message && message.length) args.releaseCommitMessageFormat = message
+  await execCommit(args, newVersion)
+  await runLifecycleScript(args, 'postcommit')
 }
 
-function execCommit (args, newVersion) {
+async function execCommit (args, newVersion) {
   let msg = 'committing %s'
   let paths = []
   const verify = args.verify === false || args.n ? ['--no-verify'] : []
@@ -51,25 +47,23 @@ function execCommit (args, newVersion) {
 
   // nothing to do, exit without commit anything
   if (args.skip.changelog && args.skip.bump && toAdd.length === 0) {
-    return Promise.resolve()
+    return
   }
 
-  return runExecFile(args, 'git', ['add'].concat(toAdd))
-    .then(() => {
-      return runExecFile(
-        args,
-        'git',
-        [
-          'commit'
-        ].concat(
-          verify,
-          sign,
-          args.commitAll ? [] : toAdd,
-          [
-            '-m',
-            `${formatCommitMessage(args.releaseCommitMessageFormat, newVersion)}`
-          ]
-        )
-      )
-    })
+  await runExecFile(args, 'git', ['add'].concat(toAdd))
+  await runExecFile(
+    args,
+    'git',
+    [
+      'commit'
+    ].concat(
+      verify,
+      sign,
+      args.commitAll ? [] : toAdd,
+      [
+        '-m',
+        `${formatCommitMessage(args.releaseCommitMessageFormat, newVersion)}`
+      ]
+    )
+  )
 }

--- a/lib/lifecycles/tag.js
+++ b/lib/lifecycles/tag.js
@@ -6,18 +6,14 @@ const formatCommitMessage = require('../format-commit-message')
 const runExecFile = require('../run-execFile')
 const runLifecycleScript = require('../run-lifecycle-script')
 
-module.exports = function (newVersion, pkgPrivate, args) {
-  if (args.skip.tag) return Promise.resolve()
-  return runLifecycleScript(args, 'pretag')
-    .then(() => {
-      return execTag(newVersion, pkgPrivate, args)
-    })
-    .then(() => {
-      return runLifecycleScript(args, 'posttag')
-    })
+module.exports = async function (newVersion, pkgPrivate, args) {
+  if (args.skip.tag) return
+  await runLifecycleScript(args, 'pretag')
+  await execTag(newVersion, pkgPrivate, args)
+  await runLifecycleScript(args, 'posttag')
 }
 
-function execTag (newVersion, pkgPrivate, args) {
+async function execTag (newVersion, pkgPrivate, args) {
   let tagOption
   if (args.sign) {
     tagOption = '-s'
@@ -25,21 +21,19 @@ function execTag (newVersion, pkgPrivate, args) {
     tagOption = '-a'
   }
   checkpoint(args, 'tagging release %s%s', [args.tagPrefix, newVersion])
-  return runExecFile(args, 'git', ['tag', tagOption, args.tagPrefix + newVersion, '-m', `${formatCommitMessage(args.releaseCommitMessageFormat, newVersion)}`])
-    .then(() => runExecFile('', 'git', ['rev-parse', '--abbrev-ref', 'HEAD']))
-    .then((currentBranch) => {
-      let message = 'git push --follow-tags origin ' + currentBranch.trim()
-      if (pkgPrivate !== true && bump.getUpdatedConfigs()['package.json']) {
-        message += ' && npm publish'
-        if (args.prerelease !== undefined) {
-          if (args.prerelease === '') {
-            message += ' --tag prerelease'
-          } else {
-            message += ' --tag ' + args.prerelease
-          }
-        }
+  await runExecFile(args, 'git', ['tag', tagOption, args.tagPrefix + newVersion, '-m', `${formatCommitMessage(args.releaseCommitMessageFormat, newVersion)}`])
+  const currentBranch = await runExecFile('', 'git', ['rev-parse', '--abbrev-ref', 'HEAD'])
+  let message = 'git push --follow-tags origin ' + currentBranch.trim()
+  if (pkgPrivate !== true && bump.getUpdatedConfigs()['package.json']) {
+    message += ' && npm publish'
+    if (args.prerelease !== undefined) {
+      if (args.prerelease === '') {
+        message += ' --tag prerelease'
+      } else {
+        message += ' --tag ' + args.prerelease
       }
+    }
+  }
 
-      checkpoint(args, 'Run `%s` to publish', [message], chalk.blue(figures.info))
-    })
+  checkpoint(args, 'Run `%s` to publish', [message], chalk.blue(figures.info))
 }

--- a/lib/run-exec.js
+++ b/lib/run-exec.js
@@ -1,20 +1,18 @@
-const exec = require('child_process').exec
+const { promisify } = require('util')
 const printError = require('./print-error')
 
-module.exports = function (args, cmd) {
-  if (args.dryRun) return Promise.resolve()
-  return new Promise((resolve, reject) => {
-    // Exec given cmd and handle possible errors
-    exec(cmd, function (err, stdout, stderr) {
-      // If exec returns content in stderr, but no error, print it as a warning
-      // If exec returns an error, print it and exit with return code 1
-      if (err) {
-        printError(args, stderr || err.message)
-        return reject(err)
-      } else if (stderr) {
-        printError(args, stderr, { level: 'warn', color: 'yellow' })
-      }
-      return resolve(stdout)
-    })
-  })
+const exec = promisify(require('child_process').exec)
+
+module.exports = async function (args, cmd) {
+  if (args.dryRun) return
+  try {
+    const { stderr, stdout } = await exec(cmd)
+    // If exec returns content in stderr, but no error, print it as a warning
+    if (stderr) printError(args, stderr, { level: 'warn', color: 'yellow' })
+    return stdout
+  } catch (error) {
+    // If exec returns an error, print it and exit with return code 1
+    printError(args, error.stderr || error.message)
+    throw error
+  }
 }

--- a/lib/run-execFile.js
+++ b/lib/run-execFile.js
@@ -1,20 +1,18 @@
-const { execFile } = require('child_process')
+const { promisify } = require('util')
 const printError = require('./print-error')
 
-module.exports = function (args, cmd, cmdArgs) {
-  if (args.dryRun) return Promise.resolve()
-  return new Promise((resolve, reject) => {
-    // Exec given cmd and handle possible errors
-    execFile(cmd, cmdArgs, function (err, stdout, stderr) {
-      // If exec returns content in stderr, but no error, print it as a warning
-      // If exec returns an error, print it and exit with return code 1
-      if (err) {
-        printError(args, stderr || err.message)
-        return reject(err)
-      } else if (stderr) {
-        printError(args, stderr, { level: 'warn', color: 'yellow' })
-      }
-      return resolve(stdout)
-    })
-  })
+const execFile = promisify(require('child_process').execFile)
+
+module.exports = async function (args, cmd, cmdArgs) {
+  if (args.dryRun) return
+  try {
+    const { stderr, stdout } = await execFile(cmd, cmdArgs)
+    // If execFile returns content in stderr, but no error, print it as a warning
+    if (stderr) printError(args, stderr, { level: 'warn', color: 'yellow' })
+    return stdout
+  } catch (error) {
+    // If execFile returns an error, print it and exit with return code 1
+    printError(args, error.stderr || error.message)
+    throw error
+  }
 }


### PR DESCRIPTION
The current code style of this library is promise-based, using long chains of then/catch blocks. This PR replaces those in favour of async/await, which is well supported in Node.js 10, the minimum required by `standard-version`.

The logic of the code does not change here at all, but this allows for the code to have significantly less boilerplate syntax. Data flow is also simplified a little bit.