### PR TITLE
feat: support bumping python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,16 @@ As of version `7.1.0` you can configure multiple `bumpFiles` and `packageFiles`.
       "type": "json"
     },
     {
+      "filename": "setup.py",
+      // The `python` updater assumes the version is available under a `version` key in the provided setup.py
+      "updater": "python"
+    },
+    {
+      "filename": "pyproject.toml",
+      // The `python` updater also supports pyproject.toml
+      "updater": "python"
+    },
+    {
       "filename": "VERSION_TRACKER.json",
       //  See "Custom `updater`s" for more details.
       "updater": "standard-version-updater.js"

--- a/lib/updaters/index.js
+++ b/lib/updaters/index.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const JSON_BUMP_FILES = require('../../defaults').bumpFiles
 const PLAIN_TEXT_BUMP_FILES = ['VERSION.txt', 'version.txt']
+const PYTHON_BUMP_FILES = ['setup.py', 'pyproject.toml']
 
 function getUpdaterByType (type) {
   try {
@@ -16,6 +17,9 @@ function getUpdaterByFilename (filename) {
   }
   if (PLAIN_TEXT_BUMP_FILES.includes(filename)) {
     return getUpdaterByType('plain-text')
+  }
+  if (PYTHON_BUMP_FILES.includes(filename)) {
+    return getUpdaterByType('python')
   }
   throw Error(
     `Unsupported file (${filename}) provided for bumping.\n Please specifcy the updater \`type\` or use a custom \`updater\`.`

--- a/lib/updaters/types/python.js
+++ b/lib/updaters/types/python.js
@@ -1,0 +1,29 @@
+const semverRegex = /version[" ]*=[ ]*["'](.*)["']/i
+
+const getVersionIndex = function (lines) {
+  let version
+  const lineNumber = lines.findIndex(line => {
+    const found = line.match(semverRegex)
+    if (found == null) {
+      return false
+    }
+    version = found[1]
+    return true
+  })
+  return { version, lineNumber }
+}
+
+module.exports.readVersion = function (contents) {
+  const lines = contents.split('\n')
+  const versionIndex = getVersionIndex(lines)
+  return versionIndex.version
+}
+
+module.exports.writeVersion = function (contents, version) {
+  const lines = contents.split('\n')
+  const versionIndex = getVersionIndex(lines)
+  const versionLine = lines[versionIndex.lineNumber]
+  const newVersionLine = versionLine.replace(versionIndex.version, version)
+  lines[versionIndex.lineNumber] = newVersionLine
+  return lines.join('\n')
+}

--- a/test.js
+++ b/test.js
@@ -1032,6 +1032,79 @@ describe('standard-version', function () {
     })
   })
 
+  describe('python support', async function () {
+    beforeEach(function () {
+      fs.copyFileSync('../test/mocks/setup-1.0.0.py', 'setup.py')
+      fs.copyFileSync('../test/mocks/pyproject-1.0.0.toml', 'pyproject.toml')
+      commit('feat: new feature!')
+    })
+
+    afterEach(function () {
+      fs.unlinkSync('setup.py')
+      fs.unlinkSync('pyproject.toml')
+    })
+
+    it('bumps version # by type', async function () {
+      await require('./index')({
+        silent: true,
+        packageFiles: [
+          {
+            filename: 'setup.py',
+            type: 'python'
+          },
+          {
+            filename: 'pyproject.toml',
+            type: 'python'
+          }
+        ],
+        bumpFiles: [
+          {
+            filename: 'setup.py',
+            type: 'python'
+          },
+          {
+            filename: 'pyproject.toml',
+            type: 'python'
+          }
+        ]
+      })
+
+      const setupPyExpected = fs.readFileSync('../test/mocks/setup-1.1.0.py', 'utf-8')
+      fs.readFileSync('setup.py', 'utf-8').should.equal(setupPyExpected)
+
+      const pyprojectExpected = fs.readFileSync('../test/mocks/pyproject-1.1.0.toml', 'utf-8')
+      fs.readFileSync('pyproject.toml', 'utf-8').should.equal(pyprojectExpected)
+    })
+
+    it('bumps version # by filename', async function () {
+      await require('./index')({
+        silent: true,
+        packageFiles: [
+          {
+            filename: 'setup.py'
+          },
+          {
+            filename: 'pyproject.toml'
+          }
+        ],
+        bumpFiles: [
+          {
+            filename: 'setup.py'
+          },
+          {
+            filename: 'pyproject.toml'
+          }
+        ]
+      })
+
+      const setupPyExpected = fs.readFileSync('../test/mocks/setup-1.1.0.py', 'utf-8')
+      fs.readFileSync('setup.py', 'utf-8').should.equal(setupPyExpected)
+
+      const pyprojectExpected = fs.readFileSync('../test/mocks/pyproject-1.1.0.toml', 'utf-8')
+      fs.readFileSync('pyproject.toml', 'utf-8').should.equal(pyprojectExpected)
+    })
+  })
+
   describe('dry-run', function () {
     it('skips all non-idempotent steps', function (done) {
       commit('feat: first commit')

--- a/test/mocks/pyproject-1.0.0.toml
+++ b/test/mocks/pyproject-1.0.0.toml
@@ -1,0 +1,13 @@
+[tool.poetry]
+name = "test"
+version = "1.0.0"
+description = ""
+authors = []
+
+[tool.poetry.dependencies]
+python = "^3.8"
+
+[build-system]
+requires = ["poetry>=1"]
+build-backend = "poetry.masonry.api"
+ 

--- a/test/mocks/pyproject-1.1.0.toml
+++ b/test/mocks/pyproject-1.1.0.toml
@@ -1,0 +1,13 @@
+[tool.poetry]
+name = "test"
+version = "1.1.0"
+description = ""
+authors = []
+
+[tool.poetry.dependencies]
+python = "^3.8"
+
+[build-system]
+requires = ["poetry>=1"]
+build-backend = "poetry.masonry.api"
+ 

--- a/test/mocks/setup-1.0.0.py
+++ b/test/mocks/setup-1.0.0.py
@@ -1,0 +1,6 @@
+from setuptools import setup
+setup(
+    name="test",
+    version="1.0.0",
+    install_requires=[],
+)

--- a/test/mocks/setup-1.1.0.py
+++ b/test/mocks/setup-1.1.0.py
@@ -1,0 +1,6 @@
+from setuptools import setup
+setup(
+    name="test",
+    version="1.1.0",
+    install_requires=[],
+)


### PR DESCRIPTION
Similar to https://github.com/conventional-changelog/standard-version/pull/638 and https://github.com/conventional-changelog/standard-version/pull/591, we've been adopting this tool in a predominantly Python codebase.

`setup.py`s aren't as structured as `package.json`, so just doing a regex find and replace. Could maybe be done smarter, but it works. `pyproject.toml` is a bit more structured but didn't want to add a TOML parser dependency, and this does the job.