### PR TITLE
fix(deps): bump conventionalcommits to 4.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "chalk": "^2.4.2",
     "conventional-changelog": "3.1.21",
     "conventional-changelog-config-spec": "2.1.0",
-    "conventional-changelog-conventionalcommits": "4.3.0",
+    "conventional-changelog-conventionalcommits": "4.3.1",
     "conventional-recommended-bump": "6.0.9",
     "detect-indent": "^6.0.0",
     "detect-newline": "^3.1.0",


### PR DESCRIPTION
Update the `conventional-changelog-conventionalcommits` dependency to version `4.3.1` from `4.3.0` to address security vulnerabilities outlined in https://npmjs.com/advisories/1213, present in chain-dependency `dot-prop` which has since been fixed upstream.

Closes #642 