### PR TITLE
feat: allow the tag message to appear as the title of releases in change log

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const path = require('path')
 const printError = require('./lib/print-error')
 const tag = require('./lib/lifecycles/tag')
 const { resolveUpdaterObjectFromArgument } = require('./lib/updaters')
+const formatCommitMessage = require('./lib/format-commit-message')
 
 module.exports = function standardVersion (argv) {
   const defaults = require('./defaults')
@@ -72,13 +73,14 @@ module.exports = function standardVersion (argv) {
       // if bump runs, it calculaes the new version that we
       // should release at.
       if (_newVersion) newVersion = _newVersion
-      return changelog(args, newVersion)
-    })
-    .then(() => {
-      return commit(args, newVersion)
-    })
-    .then(() => {
-      return tag(newVersion, pkg ? pkg.private : false, args)
+      const tagMessage = formatCommitMessage(args.releaseCommitMessageFormat, newVersion)
+      return changelog(args, newVersion, tagMessage)
+        .then(() => {
+          return commit(args, newVersion, tagMessage)
+        })
+        .then(() => {
+          return tag(newVersion, pkg ? pkg.private : false, args, tagMessage)
+        })
     })
     .catch((err) => {
       printError(args, err.message)

--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -8,11 +8,11 @@ const runLifecycleScript = require('../run-lifecycle-script')
 const writeFile = require('../write-file')
 const START_OF_LAST_RELEASE_PATTERN = /(^#+ \[?[0-9]+\.[0-9]+\.[0-9]+|<a name=)/m
 
-function Changelog (args, newVersion) {
+function Changelog (args, newVersion, tagMessage) {
   if (args.skip.changelog) return Promise.resolve()
   return runLifecycleScript(args, 'prechangelog')
     .then(() => {
-      return outputChangelog(args, newVersion)
+      return outputChangelog(args, newVersion, tagMessage)
     })
     .then(() => {
       return runLifecycleScript(args, 'postchangelog')
@@ -23,7 +23,7 @@ Changelog.START_OF_LAST_RELEASE_PATTERN = START_OF_LAST_RELEASE_PATTERN
 
 module.exports = Changelog
 
-function outputChangelog (args, newVersion) {
+function outputChangelog (args, newVersion, tagMessage) {
   return new Promise((resolve, reject) => {
     createIfMissing(args)
     const header = args.header
@@ -35,7 +35,10 @@ function outputChangelog (args, newVersion) {
       oldContent = oldContent.substring(oldContentStart)
     }
     let content = ''
-    const context = { version: newVersion }
+    const context = {
+      version: newVersion,
+      title: args.tagMessageInChangeLog && title
+    }
     const changelogStream = conventionalChangelog({
       debug: args.verbose && console.info.bind(console, 'conventional-changelog'),
       preset: presetLoader(args),

--- a/lib/lifecycles/commit.js
+++ b/lib/lifecycles/commit.js
@@ -1,23 +1,22 @@
 const bump = require('../lifecycles/bump')
 const checkpoint = require('../checkpoint')
-const formatCommitMessage = require('../format-commit-message')
 const path = require('path')
 const runExecFile = require('../run-execFile')
 const runLifecycleScript = require('../run-lifecycle-script')
 
-module.exports = function (args, newVersion) {
+module.exports = function (args, newVersion, tagMessage) {
   if (args.skip.commit) return Promise.resolve()
   return runLifecycleScript(args, 'precommit')
     .then((message) => {
       if (message && message.length) args.releaseCommitMessageFormat = message
-      return execCommit(args, newVersion)
+      return execCommit(args, newVersion, tagMessage)
     })
     .then(() => {
       return runLifecycleScript(args, 'postcommit')
     })
 }
 
-function execCommit (args, newVersion) {
+function execCommit (args, newVersion, tagMessage) {
   let msg = 'committing %s'
   let paths = []
   const verify = args.verify === false || args.n ? ['--no-verify'] : []
@@ -67,7 +66,7 @@ function execCommit (args, newVersion) {
           args.commitAll ? [] : toAdd,
           [
             '-m',
-            `${formatCommitMessage(args.releaseCommitMessageFormat, newVersion)}`
+            tagMessage,
           ]
         )
       )

--- a/lib/lifecycles/tag.js
+++ b/lib/lifecycles/tag.js
@@ -2,22 +2,21 @@ const bump = require('../lifecycles/bump')
 const chalk = require('chalk')
 const checkpoint = require('../checkpoint')
 const figures = require('figures')
-const formatCommitMessage = require('../format-commit-message')
 const runExecFile = require('../run-execFile')
 const runLifecycleScript = require('../run-lifecycle-script')
 
-module.exports = function (newVersion, pkgPrivate, args) {
+module.exports = function (newVersion, pkgPrivate, args, tagMessage) {
   if (args.skip.tag) return Promise.resolve()
   return runLifecycleScript(args, 'pretag')
     .then(() => {
-      return execTag(newVersion, pkgPrivate, args)
+      return execTag(newVersion, pkgPrivate, args, tagMessage)
     })
     .then(() => {
       return runLifecycleScript(args, 'posttag')
     })
 }
 
-function execTag (newVersion, pkgPrivate, args) {
+function execTag (newVersion, pkgPrivate, args, tagMessage) {
   let tagOption
   if (args.sign) {
     tagOption = '-s'
@@ -25,7 +24,7 @@ function execTag (newVersion, pkgPrivate, args) {
     tagOption = '-a'
   }
   checkpoint(args, 'tagging release %s%s', [args.tagPrefix, newVersion])
-  return runExecFile(args, 'git', ['tag', tagOption, args.tagPrefix + newVersion, '-m', `${formatCommitMessage(args.releaseCommitMessageFormat, newVersion)}`])
+  return runExecFile(args, 'git', ['tag', tagOption, args.tagPrefix + newVersion, '-m', tagMessage])
     .then(() => runExecFile('', 'git', ['rev-parse', '--abbrev-ref', 'HEAD']))
     .then((currentBranch) => {
       let message = 'git push --follow-tags origin ' + currentBranch.trim()


### PR DESCRIPTION
if you set 
```
{
  "tagMessageInChangeLog": true
}
```

in .versionrc

and run standard commit with a tag message (or accept the default)

```
standard-version  --releaseCommitMessageFormat 'the final final version!'
```
you get the tag commit message for the release in the change log:

### [0.0.26](https://example..com) "the final final version" (2020-08-05)
