### PR TITLE
fix: continue with commit when commitAll is true

### DIFF
--- a/lib/lifecycles/commit.js
+++ b/lib/lifecycles/commit.js
@@ -46,7 +46,7 @@ async function execCommit (args, newVersion) {
   checkpoint(args, msg, paths)
 
   // nothing to do, exit without commit anything
-  if (args.skip.changelog && args.skip.bump && toAdd.length === 0) {
+  if (!args.commitAll && args.skip.changelog && args.skip.bump && toAdd.length === 0) {
     return
   }
 


### PR DESCRIPTION
When running with `commitAll` but also skipping `bump` and `changelog` steps, the commit is skipped.  This change gives what I assume is the expected behavior.