### PR TITLE
support `option.append` at `conventionalChangelog(option)`

### DIFF
--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -32,11 +32,14 @@ function outputChangelog (args, newVersion) {
     }
     let content = ''
     const context = { version: newVersion }
-    const changelogStream = conventionalChangelog({
+    const options = {
       debug: args.verbose && console.info.bind(console, 'conventional-changelog'),
       preset: presetLoader(args),
       tagPrefix: args.tagPrefix
-    }, context, { merges: null, path: args.path })
+    }
+    if (typeof args.append === 'boolean') { options.append = args.append }
+
+    const changelogStream = conventionalChangelog(options, context, { merges: null, path: args.path })
       .on('error', function (err) {
         return reject(err)
       })


### PR DESCRIPTION
support `option.append` at `conventionalChangelog(option)`