### PR TITLE
chore(deps, ci): Updates nyc and moves to Codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,10 +6,14 @@ on:
 name: ci
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         node: [10, 12, 14]
+        os: [ubuntu-latest, windows-latest]
+    env: 
+        OS: ${{ matrix.os }}
+        NODE_VERSION: ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow
@@ -21,15 +25,8 @@ jobs:
       - run: node --version
       - run: npm install --engine-strict
       - run: npm test
-  windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: git fetch --prune --unshallow
-      - run: git config --global user.name 'Actions'
-      - run: git config --global user.email 'dummy@example.org'
-      - uses: actions/setup-node@v2
+      - run: npm run coverage
+      - name: Codecov
+        uses: codecov/codecov-action@v1
         with:
-          node-version: 12
-      - run: npm install
-      - run: npm test
+          env_vars: OS, NODE_VERSION

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A utility for versioning using [semver](https://semver.org/) and CHANGELOG gener
 
 ![ci](https://github.com/conventional-changelog/standard-version/workflows/ci/badge.svg)
 [![NPM version](https://img.shields.io/npm/v/standard-version.svg)](https://www.npmjs.com/package/standard-version)
-[![Coverage Status](https://coveralls.io/repos/conventional-changelog/standard-version/badge.svg?branch=)](https://coveralls.io/r/conventional-changelog/standard-version?branch=master)
+[![codecov](https://codecov.io/gh/conventional-changelog/standard-version/branch/master/graph/badge.svg?token=J7zMN7vTTd)](https://codecov.io/gh/conventional-changelog/standard-version)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 [![Community slack](http://devtoolscommunity.herokuapp.com/badge.svg)](http://devtoolscommunity.herokuapp.com)
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "posttest": "eslint .",
     "test": "nyc mocha --timeout=30000",
     "test:unit": "mocha --exclude test/git.spec.js",
+    "coverage": "nyc report --reporter=lcov",
     "release": "bin/cli.js"
   },
   "nyc": {
@@ -54,16 +55,15 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "coveralls": "^3.1.0",
     "eslint": "^7.14.0",
     "eslint-config-standard": "^16.0.2",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
-    "mocha": "^8.0.0",
-    "mock-fs": "^4.12.0",
+    "mocha": "^8.2.1",
+    "mock-fs": "^4.13.0",
     "mockery": "^2.1.0",
-    "nyc": "^14.1.1",
+    "nyc": "^15.1.0",
     "shelljs": "^0.8.4",
     "std-mocks": "^1.0.1"
   }


### PR DESCRIPTION
We dropped pushing [updates to Coveralls](https://coveralls.io/github/conventional-changelog/standard-version) from CI when we moved to GitHub actions. It looks like _most_ of the org is using Codecov as we no longer have Coveralls configured. 

- Removes coveralls integration.
- Updates GitHub actions to include CodeCov step.
- Moves OS to strategy matrix – we're now testing across multiple versions of Windows.
- Related dependency bumps.

---

- [ ] Once merged we'll need to update required status checks to reflect the new matrix.
