### PR TITLE
fix(updater): npm7 package lock's inner version not being updated

### DIFF
--- a/lib/updaters/types/json.js
+++ b/lib/updaters/types/json.js
@@ -11,6 +11,12 @@ module.exports.writeVersion = function (contents, version) {
   const indent = detectIndent(contents).indent
   const newline = detectNewline(contents)
   json.version = version
+
+  if (json.packages && json.packages['']) {
+    // package-lock v2 stores version there too
+    json.packages[''].version = version
+  }
+
   return stringifyPackage(json, indent, newline)
 }
 


### PR DESCRIPTION
NPM v7 introduces a new package-lock.json version, which now stores the project's version in two places: `lock.version` and `lock.packages[''].version`. This updates `writeVersion` to also bump the latter if present in the file.

Please let me know if you have any further questions.