### PR TITLE
feat: allow updater's readVersion and writeVersion to execute asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,13 +415,13 @@ module.exports = {
 
 An `updater` is expected to be a Javascript module with _atleast_ two methods exposed: `readVersion` and `writeVersion`.
 
-##### `readVersion(contents = string): string`
+##### `readVersion(contents = string): string | Promise<string>`
 
 This method is used to read the version from the provided file contents.
 
-The return value is expected to be a semantic version string.
+The return value is expected to resolve to a semantic version string.
 
-##### `writeVersion(contents = string, version: string): string`
+##### `writeVersion(contents = string, version: string): string | Promise<string>`
 
 This method is used to write the version to the provided contents.
 

--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -28,7 +28,7 @@ async function Bump (args, version) {
   if (!args.firstRelease) {
     const releaseType = getReleaseType(args.prerelease, release.releaseType, version)
     newVersion = semver.valid(releaseType) || semver.inc(version, releaseType, args.prerelease)
-    updateConfigs(args, newVersion)
+    await updateConfigs(args, newVersion)
   } else {
     checkpoint(args, 'skip version bump on first release', [], chalk.red(figures.cross))
   }
@@ -133,11 +133,11 @@ function bumpVersion (releaseAs, currentVersion, args) {
  * attempt to update the version number in provided `bumpFiles`
  * @param args config object
  * @param newVersion version number to update to.
- * @return void
+ * @return {Promise<void>}
  */
-function updateConfigs (args, newVersion) {
+async function updateConfigs (args, newVersion) {
   const dotgit = DotGitignore()
-  args.bumpFiles.forEach(function (bumpFile) {
+  await Promise.all(args.bumpFiles.map(async function (bumpFile) {
     const updater = resolveUpdaterObjectFromArgument(bumpFile)
     if (!updater) {
       return
@@ -149,15 +149,16 @@ function updateConfigs (args, newVersion) {
 
       if (!stat.isFile()) return
       const contents = fs.readFileSync(configPath, 'utf8')
+      const previousVersion = await updater.updater.readVersion(contents)
       checkpoint(
         args,
         'bumping version in ' + updater.filename + ' from %s to %s',
-        [updater.updater.readVersion(contents), newVersion]
+        [previousVersion, newVersion]
       )
       writeFile(
         args,
         configPath,
-        updater.updater.writeVersion(contents, newVersion)
+        await updater.updater.writeVersion(contents, newVersion)
       )
       // flag any config files that we modify the version # for
       // as having been updated.
@@ -165,7 +166,7 @@ function updateConfigs (args, newVersion) {
     } catch (err) {
       if (err.code !== 'ENOENT') console.warn(err.message)
     }
-  })
+  }))
 }
 
 module.exports = Bump


### PR DESCRIPTION
 * Modifies signature of readVersion and writeVersion to allow Promise<string> as valid return

The reason for this change is that I have a use case where I need to fetch data asynchronously for putting into a file through an updater.
This should be backwards compatible without any modification to existing solutions. It simply makes a function execute asynchronously
