### PR TITLE
fix: Upgrade mock of git-semver-tags to match overload

### DIFF
--- a/test/config-files.spec.js
+++ b/test/config-files.spec.js
@@ -53,9 +53,10 @@ function mock ({ bump, changelog, tags } = {}) {
       })
   )
 
-  mockery.registerMock('git-semver-tags', function (cb) {
+  mockery.registerMock('git-semver-tags', function (cbOrOpts, callback) {
+    const cb = typeof cbOrOpts === 'function' ? cbOrOpts : callback
     if (tags instanceof Error) cb(tags)
-    else cb(null, tags | [])
+    else cb(null, tags || [])
   })
 
   stdMocks.use()

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -69,9 +69,10 @@ function mock ({ bump, changelog, execFile, fs, pkg, tags } = {}) {
       })
   )
 
-  mockery.registerMock('git-semver-tags', function (cb) {
+  mockery.registerMock('git-semver-tags', function (cbOrOpts, callback) {
+    const cb = typeof cbOrOpts === 'function' ? cbOrOpts : callback
     if (tags instanceof Error) cb(tags)
-    else cb(null, tags | [])
+    else cb(null, tags || [])
   })
 
   if (typeof execFile === 'function') {

--- a/test/git.spec.js
+++ b/test/git.spec.js
@@ -66,7 +66,8 @@ function mock ({ bump, changelog, tags }) {
     }
   }))
 
-  mockery.registerMock('git-semver-tags', function (cb) {
+  mockery.registerMock('git-semver-tags', function (cbOrOpts, callback) {
+    const cb = typeof cbOrOpts === 'function' ? cbOrOpts : callback
     if (tags instanceof Error) cb(tags)
     else cb(null, tags || [])
   })


### PR DESCRIPTION
Solves the "cb is not a function" error in the test suite.  Not seeing the error in the CI, but happens on my local machine when directly including the package in `bump.js` via

```javascript
const conventionalRecommendedBump = require('../../../conventional-changelog/packages/conventional-recommended-bump')
```

[Source reference for git-semver-tags index.js](https://github.com/conventional-changelog/conventional-changelog/blob/git-semver-tags%404.0.0/packages/git-semver-tags/index.js#L17):
```javascript
module.exports = function gitSemverTags (opts, callback) {
  if (typeof opts === 'function') {
    callback = opts
    opts = {}
  }
```