### PR TITLE
Base the bump calculation and changelog on current version

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports = async function standardVersion (argv) {
     }
 
     const newVersion = await bump(args, version)
-    await changelog(args, newVersion)
+    await changelog(args, newVersion, version)
     await commit(args, newVersion)
     await tag(newVersion, pkg ? pkg.private : false, args)
   } catch (err) {

--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -120,7 +120,8 @@ function bumpVersion (releaseAs, currentVersion, args) {
         debug: args.verbose && console.info.bind(console, 'conventional-recommended-bump'),
         preset: presetOptions,
         path: args.path,
-        tagPrefix: args.tagPrefix
+        tagPrefix: args.tagPrefix,
+        tagFrom: (args.tagPrefix && currentVersion) ? args.tagPrefix + currentVersion : ''
       }, function (err, release) {
         if (err) return reject(err)
         else return resolve(release)

--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -8,10 +8,10 @@ const runLifecycleScript = require('../run-lifecycle-script')
 const writeFile = require('../write-file')
 const START_OF_LAST_RELEASE_PATTERN = /(^#+ \[?[0-9]+\.[0-9]+\.[0-9]+|<a name=)/m
 
-async function Changelog (args, newVersion) {
+async function Changelog (args, newVersion, currentVersion) {
   if (args.skip.changelog) return
   await runLifecycleScript(args, 'prechangelog')
-  await outputChangelog(args, newVersion)
+  await outputChangelog(args, newVersion, currentVersion)
   await runLifecycleScript(args, 'postchangelog')
 }
 
@@ -19,7 +19,7 @@ Changelog.START_OF_LAST_RELEASE_PATTERN = START_OF_LAST_RELEASE_PATTERN
 
 module.exports = Changelog
 
-function outputChangelog (args, newVersion) {
+function outputChangelog (args, newVersion, currentVersion) {
   return new Promise((resolve, reject) => {
     createIfMissing(args)
     const header = args.header
@@ -36,7 +36,11 @@ function outputChangelog (args, newVersion) {
       debug: args.verbose && console.info.bind(console, 'conventional-changelog'),
       preset: presetLoader(args),
       tagPrefix: args.tagPrefix
-    }, context, { merges: null, path: args.path })
+    }, context, {
+      merges: null,
+      path: args.path,
+      from: (args.tagPrefix && currentVersion) ? args.tagPrefix + currentVersion : ''
+    })
       .on('error', function (err) {
         return reject(err)
       })


### PR DESCRIPTION
Previously the bump suggestion and changelog generation ignored the version discovered by the code and did their own base version discovery - often times getting it wrong.

This PR requires [Conventional Commit 777](https://github.com/conventional-changelog/conventional-changelog/pull/777) or similar to be merged and deployed first, then the version of `conventional-recommended-bump` updated to match the release that contains those changes.  While this PR won't break if that's not done, it also won't gain the functionality I intended to bring.

I'm not sure whether or not to consider this a breaking change.  It might be as it changes what the recommended bump and changelog generation returns under some edge cases: specifically when the most recent tag in the commit history graph for the current commit is not the most recent release.

WRT testing: after doing a deep scan of how the testing system works here I also don't see a nice way to test the core problem, as the test mock system mocks the libraries, resulting in no ability to test the core problem: that the bump and changelog libraries weren't being fed the information they need to determine the correct base release tag.