### PR TITLE
adding YAML support

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,14 @@ npm run release -- --help
 standard-version --help
 ```
 
+### YAML support
+With CLI
+```sh
+# global bin
+standard-version --packageFiles path/to/your/file.yaml --bumpFiles path/to/your/file.yaml
+```
+Or using `.versionrc`, [see below](#can-i-use-standard-version-for-additional-metadata-files-languages-or-version-files)
+
 ## Code Usage
 
 ```js
@@ -388,7 +396,13 @@ As of version `7.1.0` you can configure multiple `bumpFiles` and `packageFiles`.
       "type": "json"
     },
     {
-      "filename": "VERSION_TRACKER.json",
+      "filename": "a/deep/package/dot/yaml/file/MY_VERSION_TRACKER.yaml",
+      // The `yaml` updater assumes the version is available under a `version` key in the provided YAML document.
+      // filename extension: yaml or yml
+      "type": "yaml"
+    },
+    {
+      "filename": "MY_VERSION_TRACKER.json",
       //  See "Custom `updater`s" for more details.
       "updater": "standard-version-updater.js"
     }

--- a/lib/updaters/index.js
+++ b/lib/updaters/index.js
@@ -2,7 +2,8 @@ const path = require('path')
 const JSON_BUMP_FILES = require('../../defaults').bumpFiles
 const updatersByType = {
   json: require('./types/json'),
-  'plain-text': require('./types/plain-text')
+  'plain-text': require('./types/plain-text'),
+  yaml: require('./types/yaml')
 }
 const PLAIN_TEXT_BUMP_FILES = ['VERSION.txt', 'version.txt']
 
@@ -20,6 +21,9 @@ function getUpdaterByFilename (filename) {
   }
   if (PLAIN_TEXT_BUMP_FILES.includes(filename)) {
     return getUpdaterByType('plain-text')
+  }
+  if (/.ya?ml$/.test(filename)) {
+    return getUpdaterByType('yaml')
   }
   throw Error(
     `Unsupported file (${filename}) provided for bumping.\n Please specify the updater \`type\` or use a custom \`updater\`.`

--- a/lib/updaters/types/yaml.js
+++ b/lib/updaters/types/yaml.js
@@ -1,0 +1,11 @@
+const YAML = require('yaml')
+
+module.exports.readVersion = function (contents) {
+  return YAML.parse(contents).version
+}
+
+module.exports.writeVersion = function (contents, version) {
+  const yaml = YAML.parse(contents)
+  yaml.version = version
+  return YAML.stringify(yaml)
+}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "git-semver-tags": "^4.0.0",
     "semver": "^7.1.1",
     "stringify-package": "^1.0.1",
+    "yaml": "^1.10.2",
     "yargs": "^16.0.0"
   },
   "devDependencies": {

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -9,6 +9,7 @@ const { Readable } = require('stream')
 const mockFS = require('mock-fs')
 const mockery = require('mockery')
 const stdMocks = require('std-mocks')
+const YAML = require('yaml')
 
 const cli = require('../command')
 const formatCommitMessage = require('../lib/format-commit-message')
@@ -543,6 +544,22 @@ describe('standard-version', function () {
         bumpFiles: [{ filename: 'VERSION_TRACKER.txt', type: 'plain-text' }]
       })
       fs.readFileSync('VERSION_TRACKER.txt', 'utf-8').should.equal('6.4.0')
+    })
+
+    it('reads and writes to a custom `yaml` file', async function () {
+      mock({
+        bump: 'minor',
+        fs: {
+          'Chart.yaml': fs.readFileSync(
+            './test/mocks/Chart-9.2.0.yaml'
+          )
+        }
+      })
+      await exec({
+        packageFiles: [{ filename: 'Chart.yaml', type: 'yaml' }],
+        bumpFiles: [{ filename: 'Chart.yaml', type: 'yaml' }]
+      })
+      YAML.parse(fs.readFileSync('Chart.yaml', 'utf-8')).version.should.equal('9.3.0')
     })
 
     it('allows same object to be used in packageFiles and bumpFiles', async function () {

--- a/test/mocks/Chart-9.2.0.yaml
+++ b/test/mocks/Chart-9.2.0.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: chart-project
+description: A Helm chart for Kubernetes
+type: application
+version: 9.2.0
+appVersion: 2021.04


### PR DESCRIPTION
Hi,

As we working with some Helm charts, and using conventional commits, we also think that it could be a good idea to use standard-version on them but YAML support does not exist.
As Chart.yaml got a `version` key we decided to bring you this PR to support YAML file as general, assuming they have a `version` key like JSON updater