### PR TITLE
expose --skip-unstable flag from conventional-recommended-bump

### DIFF
--- a/command.js
+++ b/command.js
@@ -103,6 +103,10 @@ const yargs = require('yargs')
     type: 'string',
     describe: 'Name of the package from which the tags will be extracted'
   })
+  .option('skip-unstable', {
+    type: 'boolean',
+    describe: 'If true, unstable tags will be skipped for determining the most recent tag, e.g., x.x.x-alpha.1, x.x.x-rc.2'
+  })
   .check((argv) => {
     if (typeof argv.scripts !== 'object' || Array.isArray(argv.scripts)) {
       throw Error('scripts must be an object')

--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -121,7 +121,8 @@ function bumpVersion (releaseAs, currentVersion, args) {
         preset: presetOptions,
         path: args.path,
         tagPrefix: args.tagPrefix,
-        lernaPackage: args.lernaPackage
+        lernaPackage: args.lernaPackage,
+        skipUnstable: args.skipUnstable
       }, function (err, release) {
         if (err) return reject(err)
         else return resolve(release)


### PR DESCRIPTION
conventional-recommended-bump supports a [`skipUnstable`](https://github.com/conventional-changelog/conventional-changelog/blob/3b0fb22b0bb49137b9ecddaeb349f66025205c57/packages/conventional-recommended-bump/README.md#skipunstable) option which would be very useful for projects that use standard-version and want to make release candidates

I wanted to have this feature supported so I could:
- make a v1.0.0
- make a v2.0.0-beta.0
- make a v2.0.0
- see the CHANGELOG for the commits between v1.0.0 and v2.0.0, not v1.0.0 -> v2.0.0-beta.0 + v2.0.0-beta.0 -> v2.0.0