### PR TITLE
Combining both release-as and prerelease now doesn't break package version

### DIFF
--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -27,7 +27,9 @@ async function Bump (args, version) {
   const release = await bumpVersion(args.releaseAs, version, args)
   if (!args.firstRelease) {
     const releaseType = getReleaseType(args.prerelease, release.releaseType, version)
-    newVersion = semver.valid(releaseType) || semver.inc(version, releaseType, args.prerelease)
+    const releaseTypeAsVersion = releaseType === 'pre' + release.releaseType ? semver.valid(release.releaseType + '-' + args.prerelease + '.0') : semver.valid(releaseType)
+
+    newVersion = releaseTypeAsVersion || semver.inc(version, releaseType, args.prerelease)
     updateConfigs(args, newVersion)
   } else {
     checkpoint(args, 'skip version bump on first release', [], chalk.red(figures.cross))

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -13,7 +13,7 @@ const stdMocks = require('std-mocks')
 const cli = require('../command')
 const formatCommitMessage = require('../lib/format-commit-message')
 
-require('chai').should()
+const should = require('chai').should()
 
 // set by mock()
 let standardVersion
@@ -353,6 +353,42 @@ describe('cli', function () {
         })
         await exec('--release-as 200.0.0-amazing')
         getPackageVersion().should.equal('200.0.0-amazing')
+      })
+
+      it('releases as 100.0.0 with prerelease amazing', async function () {
+        mock({
+          bump: 'patch',
+          fs: { 'CHANGELOG.md': 'legacy header format<a name="1.0.0">\n' },
+          pkg: {
+            version: '1.0.0'
+          }
+        })
+        await exec('--release-as 100.0.0 --prerelease amazing')
+        should.equal(getPackageVersion(), '100.0.0-amazing.0')
+      })
+
+      it('release 100.0.0 with prerelease amazing bumps build', async function () {
+        mock({
+          bump: 'patch',
+          fs: { 'CHANGELOG.md': 'legacy header format<a name="100.0.0-amazing.0">\n' },
+          pkg: {
+            version: '100.0.0-amazing.0'
+          }
+        })
+        await exec('--release-as 100.0.0 --prerelease amazing')
+        should.equal(getPackageVersion(), '100.0.0-amazing.1')
+      })
+
+      it('release 100.0.0-amazing.0 with prerelease amazing bumps build', async function () {
+        mock({
+          bump: 'patch',
+          fs: { 'CHANGELOG.md': 'legacy header format<a name="100.0.0-amazing.0">\n' },
+          pkg: {
+            version: '100.0.0-amazing.0'
+          }
+        })
+        await exec('--release-as 100.0.0-amazing.0 --prerelease amazing')
+        should.equal(getPackageVersion(), '100.0.0-amazing.1')
       })
     })
 


### PR DESCRIPTION
Previously, as shown in #542, using both options at the same time resulted in the bump file's version being set to null.

This was validated in the first of the new unit tests. The other unit tests simply check that the rest of the behavior is correct in this case.

With this combination the user can override the version, the purpose of `release-as`, while still starting or continuing a pre-release, the purpose of of the `prerelease`.

Fixes #542