### PR TITLE
feat: allows to use semver strictly on versions less than 1.0.0

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -11,6 +11,7 @@ const defaults = {
   scripts: {},
   skip: {},
   dryRun: false,
+  strictSemver: false,
   gitTagFallback: true,
   preset: require.resolve('conventional-changelog-conventionalcommits')
 }

--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -114,7 +114,7 @@ function bumpVersion (releaseAs, currentVersion, args) {
     } else {
       const presetOptions = presetLoader(args)
       if (typeof presetOptions === 'object') {
-        if (semver.lt(currentVersion, '1.0.0')) presetOptions.preMajor = true
+        if (semver.lt(currentVersion, '1.0.0') && !args.strictSemver) presetOptions.preMajor = true
       }
       conventionalRecommendedBump({
         debug: args.verbose && console.info.bind(console, 'conventional-recommended-bump'),


### PR DESCRIPTION
This PR allows to follow the convention established by SEMVER for the version increment regardless of whether it is a stable version or not ([equal or higher than 1.0.0](https://semver.org/#spec-item-4)).

In order to follow this convention the **_strict-semver_** property is added to the initial configuration.

```javascript
const defaults = {
  infile: 'CHANGELOG.md',
  firstRelease: false,
  sign: false,
  noVerify: false,
  commitAll: false,
  silent: false,
  tagPrefix: 'v',
  scripts: {},
  skip: {},
  dryRun: false,
  strictSemver: false,
  gitTagFallback: true,
  preset: require.resolve('conventional-changelog-conventionalcommits')
}
```

By default this property will have value false to maintain the current behavior which is described in this section #347 #308 #310 

The value of **_strict-semver_** is evaluated in the _bump.js_ file to determine whether to strictly follow semver or to apply the current behavior.

```javascript
if (typeof presetOptions === 'object') {
    if (semver.lt(currentVersion, '1.0.0') && !args.strictSemver) presetOptions.preMajor = true
}
```

You can set this property as follows:

1. Set the **_strict-semver_** property to standard-version stanza in your package.json(assuming your project is JavaScript).
2. Place the **_strict-semver_** property in a _.versionrc_, _.versionrc.json_ or _.versionrc.js_.

