### PR TITLE
!chore: Drops Node.js 10 support (end-of-life), now requires Node.js >= 12.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: [10, 12, 14]
+        node: [12, 14, 16]
         os: [ubuntu-latest, windows-latest]
     env: 
         OS: ${{ matrix.os }}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "repository": "conventional-changelog/standard-version",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "keywords": [
     "conventional-changelog",


### PR DESCRIPTION
Node.js 10 has reached end-of-life (4/30/2021) and many upstream dependencies have formally dropped support. 

- Drops Node.js 10 from our test matrix.
- Adds Node.js 16 to test matrix.

see: #791,#835,#816,#792