### PR TITLE
chore: Move to native fs.accessSync, removes fs-access package.

### DIFF
--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -1,4 +1,3 @@
-const accessSync = require('fs-access').sync
 const chalk = require('chalk')
 const checkpoint = require('../checkpoint')
 const conventionalChangelog = require('conventional-changelog')
@@ -56,7 +55,7 @@ function outputChangelog (args, newVersion) {
 
 function createIfMissing (args) {
   try {
-    accessSync(args.infile, fs.F_OK)
+    fs.accessSync(args.infile, fs.F_OK)
   } catch (err) {
     if (err.code === 'ENOENT') {
       checkpoint(args, 'created %s', [args.infile])

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "dotgitignore": "^2.1.0",
     "figures": "^3.1.0",
     "find-up": "^5.0.0",
-    "fs-access": "^1.0.1",
     "git-semver-tags": "^4.0.0",
     "semver": "^7.1.1",
     "stringify-package": "^1.0.1",


### PR DESCRIPTION
closes #793