### PR TITLE
Use relative path in git ignore

### DIFF
--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -145,7 +145,7 @@ function updateConfigs (args, newVersion) {
     }
     const configPath = path.resolve(process.cwd(), updater.filename)
     try {
-      if (dotgit.ignore(configPath)) return
+      if (dotgit.ignore(updater.filename)) return
       const stat = fs.lstatSync(configPath)
 
       if (!stat.isFile()) return


### PR DESCRIPTION
Closes #902 

Hi,

Here is a patch to use the relative path when checking git ignore.

The absolute path can contain stuffs which can be matched by gitignore.
It's  not an expected behavior.

I can't tell if it's the proper way to patch this problem.