### PR TITLE
feat(deprecated): add deprecation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Standard Version
 
+> **`standard-version` is deprecated**. If you're a GitHub user, I recommend [release-please](https://github.com/googleapis/release-please) as an alternative. I encourage folks to fork this repository and, if a fork gets popular, I will link to it in this README.
+
 A utility for versioning using [semver](https://semver.org/) and CHANGELOG generation powered by [Conventional Commits](https://conventionalcommits.org).
 
 ![ci](https://github.com/conventional-changelog/standard-version/workflows/ci/badge.svg)


### PR DESCRIPTION
Unfortunately, I don't have time to continue maintaining standard-version, partially because the tool [release-please](https://github.com/googleapis/release-please) meets all my needs.

If anyone is interested in forking this repository, and the fork gets some traction, I will happy link to it from this repository (_this is where yargs came from, it was a fork of optimist_).