### PR TITLE
fix: improve console logs for skipping an updater with errors

### DIFF
--- a/lib/updaters/index.js
+++ b/lib/updaters/index.js
@@ -1,3 +1,4 @@
+const chalk = require('chalk')
 const path = require('path')
 const JSON_BUMP_FILES = require('../../defaults').bumpFiles
 const updatersByType = {
@@ -72,7 +73,11 @@ module.exports.resolveUpdaterObjectFromArgument = function (arg) {
       updater.updater = getUpdaterByFilename(updater.filename)
     }
   } catch (err) {
-    if (err.code !== 'ENOENT') console.warn(`Unable to obtain updater for: ${JSON.stringify(arg)}\n - Error: ${err.message}\n - Skipping...`)
+    if (err.code !== 'ENOENT') {
+      console.warn(`${chalk.bgYellow.bold('[Warning]')} ${chalk.yellow(`Unable to obtain updater for: ${JSON.stringify(arg)}`)}`)
+      console.warn(`- ${chalk.red.bold('[Error]')}: ${err.message}`)
+      console.warn(`- ${chalk.red('Skipping updater...')}`);
+    }
   }
   /**
    * We weren't able to resolve an updater for the argument.


### PR DESCRIPTION
This will fix my issue on: https://github.com/conventional-changelog/standard-version/issues/917