### PR TITLE
Fix/print exec catch

### DIFF
--- a/lib/print-error.js
+++ b/lib/print-error.js
@@ -1,7 +1,7 @@
 const chalk = require('chalk')
 
 module.exports = function (args, msg, opts) {
-  if (!args.silent) {
+  if (!args.silent || args.printError) {
     opts = Object.assign({
       level: 'error',
       color: 'red'

--- a/lib/run-exec.js
+++ b/lib/run-exec.js
@@ -12,7 +12,7 @@ module.exports = async function (args, cmd) {
     return stdout
   } catch (error) {
     // If exec returns an error, print it and exit with return code 1
-    printError(args, error.stderr || error.message)
+    printError(args, error.stderr || error.stdout || error.message)
     throw error
   }
 }


### PR DESCRIPTION
1. Compatible with catch exception details output in error.stdout
2. Add configuration parameters, output error when exec(cmd) exceptions facilitate troubleshooting

tks.