### PR TITLE
create ci/cd for automatically standard version when release

### DIFF
--- a/.github/workflows/standard-version.yaml
+++ b/.github/workflows/standard-version.yaml
@@ -6,11 +6,13 @@ on:
       - master
     paths:
       - "**"
+      - "!CHANGELOG.md"
   pull_request:
     branches:
       - master
     paths:
       - "**"
+      - "!CHANGELOG.md"
 
 jobs:
   build:

--- a/.github/workflows/standard-version.yaml
+++ b/.github/workflows/standard-version.yaml
@@ -1,6 +1,7 @@
 name: CI/CD Pipeline for React App with Standard-Version (PR & Official)
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -9,7 +10,7 @@ on:
       - "!CHANGELOG.md"
   pull_request:
     branches:
-      - master
+      - feature/standard-version
     paths:
       - "**"
       - "!CHANGELOG.md"

--- a/.github/workflows/standard-version.yaml
+++ b/.github/workflows/standard-version.yaml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - master
+    paths:
+      - "**"
   pull_request:
     branches:
       - master
+    paths:
+      - "**"
 
 jobs:
   build:

--- a/.github/workflows/standard-version.yaml
+++ b/.github/workflows/standard-version.yaml
@@ -1,0 +1,54 @@
+name: CI/CD Pipeline for React App with Standard-Version
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'  
+
+      - name: Install dependencies
+        run: npm install --engine-strict
+
+      - name: Run tests
+        run: npm test
+
+      - name: Run code coverage
+        run: npm run coverage
+
+      - name: Build React App
+        run: npm run build
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository with full history
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '12'
+
+      - name: Bump version and generate changelog using standard-version
+        run: npx standard-version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push changes (commits and tags)
+        run: git push --follow-tags origin main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/standard-version.yaml
+++ b/.github/workflows/standard-version.yaml
@@ -1,7 +1,10 @@
-name: CI/CD Pipeline for React App with Standard-Version
+name: CI/CD Pipeline for React App with Standard-Version (PR & Official)
 
 on:
   push:
+    branches:
+      - master
+  pull_request:
     branches:
       - master
 
@@ -11,44 +14,66 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
         with:
-          node-version: '16'  
-
-      - name: Install dependencies
-        run: npm install --engine-strict
-
-      - name: Run tests
-        run: npm test
-
-      - name: Run code coverage
-        run: npm run coverage
-
-      - name: Build React App
-        run: npm run build
-
-  release:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository with full history
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 
-
+          fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: '12'
+      - name: Install dependencies
+        run: npm install --engine-strict
+      - name: Run tests
+        run: npm test
+      - name: Run code coverage
+        run: npm run coverage 
+      - name: Build React App
+        run: npm run build
 
-      - name: Bump version and generate changelog using standard-version
-        run: npx standard-version
+  pr-release:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch with full history
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+      - name: Setup Node.js for PR
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - name: Bump version and update changelog for PR (pre-release)
+        # using flag --prerelease=pr fort adding prefix "pr" to the version commit when created PR
+        run: npx standard-version --prerelease=pr --skip.commit=true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Commit and push pre-release changes to PR branch
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add package.json CHANGELOG.md
+          git commit -m "chore(release): temporary prerelease version update"
+          git push origin HEAD:${{ github.head_ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push changes (commits and tags)
+  official-release:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main with full history
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js for Official Release
+        uses: actions/setup-node@v3
+        with:
+          node-version: '12'
+      - name: Bump version and update changelog officially
+        run: npx standard-version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push changes and tags to main
         run: git push --follow-tags origin main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Standard Version
+## Standard Version
 
 > **`standard-version` is deprecated**. If you're a GitHub user, I recommend [release-please](https://github.com/googleapis/release-please) as an alternative. If you're unable to use GitHub Actions, or if you need to stick with `standard-version` for some other reason, you can use the [commit-and-tag-version]( https://github.com/absolute-version/commit-and-tag-version) fork of `standard-version`.
 


### PR DESCRIPTION
Create CI/CD when a new PR would like to be merged to the master branch and automatically to create tag and version on channelog