### PR TITLE
ci: Add Qlty code coverage reporting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,9 @@ jobs:
       - run: npm install --engine-strict
       - run: npm test
       - run: npm run coverage
-      - name: Codecov
-        uses: codecov/codecov-action@v2
+      - name: Upload coverage to Qlty
+        uses: qltysh/qlty-action/coverage@v2
         with:
-          env_vars: OS, NODE_VERSION
+          token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+          files: coverage/lcov.info
+          total-parts-count: 6


### PR DESCRIPTION
## Summary

- Replace Codecov with Qlty Cloud for code coverage reporting
- Use `qltysh/qlty-action/coverage@v2` GitHub Action for uploads
- Configure server-side coverage merging with `total-parts-count: 6` to combine reports from all matrix jobs (Node 10/12/14 × ubuntu/windows)
- Authenticate via coverage token stored in `QLTY_COVERAGE_TOKEN` secret

## Manual steps required

1. **Add the `QLTY_COVERAGE_TOKEN` secret** to this repository:
   - Go to [Qlty Cloud](https://qlty.sh) → Workspace Settings → Code Coverage → copy the coverage token
   - Go to this repo's Settings → Secrets and variables → Actions → New repository secret
   - Name: `QLTY_COVERAGE_TOKEN`, Value: the copied token

## Test plan

- [ ] Verify CI workflow runs successfully after adding the secret
- [ ] Confirm coverage data appears in Qlty Cloud dashboard
- [ ] Verify all 6 matrix job reports are merged correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)